### PR TITLE
Make the standalone viewer downloadable 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ install:
     # git describe
     - git fetch --unshallow
     - npm ci
-    - python3 -m pip install -r docs/requirements.txt
+    - python3 -m pip install -r docs/requirements.txt    
+    - python3 -m pip install beautifulsoup4 requests
 
 script:
     # Build the code
@@ -27,8 +28,8 @@ script:
     # Build the website & standalone version
     - npm run download-example-input
     - cp -r app/ gh-pages/
+    - cp dist/*.min.js gh-pages/    
     - python3 utils/generate_standalone.py -o gh-pages/chemiscope_standalone.html    
-    - cp dist/*.min.js gh-pages/
     - touch gh-pages/.nojekyll
     - echo "chemiscope.org" > gh-pages/CNAME
     # Cleanup a few files

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ script:
     - npm run merge-dts
     # Run tests & lints
     - npm test
-    # Build the website
+    # Build the website & standalone version
     - npm run download-example-input
     - cp -r app/ gh-pages/
+    - python3 utils/generate_standalone.py -o gh-pages/chemiscope_standalone.html    
     - cp dist/*.min.js gh-pages/
     - touch gh-pages/.nojekyll
     - echo "chemiscope.org" > gh-pages/CNAME

--- a/app/index.html
+++ b/app/index.html
@@ -46,10 +46,10 @@
                         <li class="nav-item">
                             <a class="nav-link" data-toggle="modal" href="#about"><i class="fa fa-user"></i> About</a>
                         </li>
-                        <li class="nav-item">
+                        <li class="nav-item hide-if-standalone">
                             <a class="nav-link" data-toggle="modal" href="#download"><i class="fa fa-download"></i> Download</a>                        
                         </li>
-                        <li class="nav-item dropdown">
+                        <li class="nav-item dropdown hide-if-standalone">
                             <a class="nav-link dropdown-toggle" href="#" id="examples" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <i class="fa fa-images"></i> Examples
                             </a>

--- a/app/index.html
+++ b/app/index.html
@@ -47,7 +47,7 @@
                             <a class="nav-link" data-toggle="modal" href="#about"><i class="fa fa-user"></i> About</a>
                         </li>
                         <li class="nav-item hide-if-standalone">
-                            <a class="nav-link" data-toggle="modal" href="#download"><i class="fa fa-download"></i> Download</a>                        
+                            <a class="nav-link" data-toggle="modal" href="#download"><i class="fa fa-download"></i> Download</a>
                         </li>
                         <li class="nav-item dropdown hide-if-standalone">
                             <a class="nav-link dropdown-toggle" href="#" id="examples" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -193,26 +193,26 @@
               </div>
               <div class="modal-body">
                 <p>
-                    Chemiscope consists in a set of JavaScript modules to 
-                    visualize atomic structures and map associated data. 
+                    Chemiscope consists in a set of JavaScript modules to
+                    visualize atomic structures and map associated data.
                     These modules can be assembled into all sorts of interactive
                     visualization tools, such as that which you can use on these
-                    pages. 
+                    pages.
                 </p>
 
                 <p>
                     If you are a developer you may be interested in downloading
                     the <a href="https://github.com/cosmo-epfl/chemiscope"> source code</a>,
-                    which is available on GitHub. 
+                    which is available on GitHub.
                 </p>
 
                 <p>
-                    If you are a user, you may want to download a 
-                    <a href="chemiscope_standalone.html" download> 
+                    If you are a user, you may want to download a
+                    <a href="chemiscope_standalone.html" download>
                     standalone version
-                    </a> of the standard viewer, which you can use to 
-                    display locally datasets prepared in the chemiscope 
-                    JSON format. 
+                    </a> of the standard viewer, which you can use to
+                    display locally datasets prepared in the chemiscope
+                    JSON format.
 
                 </p>
               </div>
@@ -230,13 +230,19 @@
             const version = document.getElementById('chemiscope-version');
             version.innerText = `version ${Chemiscope.version()}`;
 
-            setupDefaultChemiscope(isStandalone);
+            const j2sPath = isStandalone ?
+                'https://chemapps.stolaf.edu/jmol/jsmol-2019-10-30/j2s/' :
+                'static/js/jsmol/j2s';
+            setupDefaultChemiscope(j2sPath);
+
             if (!isStandalone) {
                 loadExample('Arginine-Dipeptide.json.gz');
             } else {
                 const data = standalone.innerText;
                 if (data.trim() !== "") {
                     setupChemiscope(JSON.parse(standalone.innerText));
+                } else {
+                    document.getElementById('loading').style.display = "none";
                 }
             }
         })

--- a/app/index.html
+++ b/app/index.html
@@ -47,7 +47,7 @@
                             <a class="nav-link" data-toggle="modal" href="#about"><i class="fa fa-user"></i> About</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="https://github.com/cosmo-epfl/chemiscope"><i class="fab fa-github"></i> Source</a>
+                            <a class="nav-link" data-toggle="modal" href="#download"><i class="fa fa-download"></i> Download</a>                        
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="examples" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -176,6 +176,45 @@
                         <br/>S De, AP Bartók, G Csányi, M Ceriotti - PCCP, 2016
                     </li>
                 </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal fade" tabindex="-1" id='download'>
+          <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title">
+                    Download chemiscope
+                </h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                <p>
+                    Chemiscope consists in a set of JavaScript modules to 
+                    visualize atomic structures and map associated data. 
+                    These modules can be assembled into all sorts of interactive
+                    visualization tools, such as that which you can use on these
+                    pages. 
+                </p>
+
+                <p>
+                    If you are a developer you may be interested in downloading
+                    the <a href="https://github.com/cosmo-epfl/chemiscope"> source code</a>,
+                    which is available on GitHub. 
+                </p>
+
+                <p>
+                    If you are a user, you may want to download a 
+                    <a href="chemiscope_standalone.html" download> 
+                    standalone version
+                    </a> of the standard viewer, which you can use to 
+                    display locally datasets prepared in the chemiscope 
+                    JSON format. 
+
+                </p>
               </div>
             </div>
           </div>

--- a/app/static/js/default.js
+++ b/app/static/js/default.js
@@ -16,7 +16,7 @@ function toJson(path, buffer) {
 
 let VISUALIZER = undefined;
 let DATASET = undefined;
-let ORIGINAL_LOAD_STRUCTURE = undefined;
+let J2S_PATH = undefined;
 
 function loadStructureOnDemand(index, structure) {
     /**
@@ -36,10 +36,10 @@ function setupChemiscope(dataset) {
         info:      'chemiscope-info',
         meta:      'chemiscope-meta',
         structure: 'chemiscope-structure',
-        j2sPath:   GLOBAL_J2S_PATH,
+        j2sPath:   J2S_PATH,
     };
 
-    if (DATASET === "Azaphenacenes.json.gz") {
+    if (DATASET.includes("Azaphenacenes.json.gz")) {
         // example of asynchronous structure loading
         config.loadStructure = loadStructureOnDemand;
     }
@@ -120,7 +120,8 @@ function loadExample(url) {
         .catch(e => setTimeout(() => {throw e;}));
 }
 
-function setupDefaultChemiscope(isStandalone) {
+function setupDefaultChemiscope(j2sPath) {
+    J2S_PATH = j2sPath;
     Chemiscope.addWarningHandler((message) => displayWarning(message));
 
     window.onerror = (msg, url, line, col, error) => {
@@ -138,12 +139,5 @@ function setupDefaultChemiscope(isStandalone) {
             setupChemiscope(json);
         }
         reader.readAsArrayBuffer(upload.files[0]);
-    }
-
-    if (isStandalone) {
-        document.getElementById('examples').style.display = 'none';
-        window.GLOBAL_J2S_PATH = 'https://chemapps.stolaf.edu/jmol/jsmol-2019-10-30/j2s/';
-    } else {
-        window.GLOBAL_J2S_PATH = 'static/js/jsmol/j2s';
     }
 }

--- a/utils/generate_standalone.py
+++ b/utils/generate_standalone.py
@@ -108,6 +108,7 @@ def main():
 
     with open(output_name, 'w') as fd:
         fd.write(str(html))
+        fd.write('<script type="text/javascript"> for (const element of document.getElementsByClassName("hide-if-standalone") ) { element.style.display = "none"; } </script>')
         fd.write('<script id=standalone-json-data type="application/json">')
         fd.write(json_data)
         


### PR DESCRIPTION
Travis deploys chemiscope_standalone.html when it builds the website. A button is added to make it downloadable. 