### PR TITLE
Option to automatically center the selected environment in the viewer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ node_js:
   - 12
 
 install:
+    # we need the full history to be able to get the chemiscope version with
+    # git describe
+    - git fetch --unshallow
     - npm ci
     - python3 -m pip install -r docs/requirements.txt
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ class DefaultVisualizer {
         getByID(this._ids.map).innerHTML = '';
         getByID(this._ids.meta).innerHTML = '';
         getByID(this._ids.info).innerHTML = '';
-        getByID(this._ids.structure).innerHTML = '';
+        getByID(this._ids.structure).innerHTML = '';                
     }
 }
 

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -283,6 +283,12 @@
 .chsp-settings-environments {
     display: grid;
     grid-gap: 1em;
+    grid-template-columns: 3fr 2fr 3fr 2fr;
+}
+
+.chsp-settings-environments-bg {
+    display: grid;
+    grid-gap: 1em;
     grid-template-columns: 1fr 1fr 1fr;
 }
 

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -283,12 +283,6 @@
 .chsp-settings-environments {
     display: grid;
     grid-gap: 1em;
-    grid-template-columns: 3fr 2fr 3fr 2fr;
-}
-
-.chsp-settings-environments-bg {
-    display: grid;
-    grid-gap: 1em;
     grid-template-columns: 1fr 1fr 1fr;
 }
 

--- a/src/structure/settings.html
+++ b/src/structure/settings.html
@@ -76,25 +76,29 @@
                     <div style="margin-bottom: 1.5em;"></div>
                     <h5 class="chsp-settings-section-title">Environments</h5>
                     <div class="chsp-settings-environments">
+                        <div class="btn-group-toggle" data-toggle="buttons">
+                        <label class="btn btn-primary btn-sm active" style="width: 100%">
+                            <input type="checkbox" id=env-activated> Enable
+                        </label>
+                        </div>
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox" class="custom-control-input" id=auto-center>
+                            <label class="custom-control-label" for=auto-center title="center automatically structure or environment in the viewport" style="cursor: help;">center</label>
+                        </div>
+                                                
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
                                <label class="input-group-text" for=env-cutoff>cutoff</label>
                              </div>
                              <input class="form-control" id=env-cutoff type="number" min="0" max= "50" step="0.1">
                         </div>
-
-                        <button class="btn btn-secondary btn-sm" id=env-reset>reset cutoff</button>
-
-                        <div class="btn-group-toggle" data-toggle="buttons">
-                        <label class="btn btn-primary btn-sm active" style="width: 100%">
-                            <input type="checkbox" id=env-activated> Enable
-                        </label>
-                        </div>
-
+                        <button class="btn btn-secondary btn-sm" id=env-reset>reset</button>
+                    </div>
+                    <div style="margin-bottom: 0.8em;"></div>
+                    <div class="chsp-settings-environments-bg">                        
                         <div>
                             <span style="vertical-align: middle">Background atoms</span>
                         </div>
-
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
                                <label class="input-group-text" for=env-bg-color>color</label>
@@ -103,10 +107,9 @@
                                  <option value="CPK">CPK</option>
                                  <option value="grey">grey</option>
                              </select>
-                         </div>
-
-                         <div class="input-group input-group-sm">
-                             <div class="input-group-prepend">
+                        </div>
+                        <div class="input-group input-group-sm">
+                            <div class="input-group-prepend">
                                 <label class="input-group-text" for=env-bg-style>style</label>
                               </div>
                               <select id=env-bg-style class="custom-select">
@@ -114,7 +117,7 @@
                                   <option value="ball-stick">ball and stick</option>
                                   <option value="hide">hide</option>
                               </select>
-                          </div>
+                        </div>                        
                     </div>
                 </div>
 
@@ -140,11 +143,10 @@
                             </div>
                             <input id=playback-delay class="form-control" type="number" min=1 value=7>
                         </div>
-
                         <div class="custom-control custom-switch">
                             <input type="checkbox" class="custom-control-input" id=keep-orientation>
                             <label class="custom-control-label" for=keep-orientation title="keep the camera orientation when loading a new molecule" style="cursor: help;">keep orientation</label>
-                        </div>
+                        </div>                        
                     </div>
                 </div>
             </div>

--- a/src/structure/settings.html
+++ b/src/structure/settings.html
@@ -89,8 +89,11 @@
                             more options
                         </button>
                         <div class="collapse chsp-settings-extra-options" id=chsp-extra-env>
+                            <div> 
+                            	  <span style="vertical-align: middle">Highlight region</span>
+                            </div>
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
+                                 <div class="input-group-prepend">
                                    <label class="input-group-text" for=env-cutoff>cutoff</label>
                                  </div>
                                  <input class="form-control" id=env-cutoff type="number" min="0" max= "50" step="0.1">

--- a/src/structure/settings.html
+++ b/src/structure/settings.html
@@ -92,7 +92,7 @@
                              </div>
                              <input class="form-control" id=env-cutoff type="number" min="0" max= "50" step="0.1">
                         </div>
-                        <button class="btn btn-secondary btn-sm" id=env-reset>reset</button>
+                        <button class="btn btn-sm btn-light" id=env-reset>reset</button>
                     </div>
                     <div style="margin-bottom: 0.8em;"></div>
                     <div class="chsp-settings-environments-bg">                        

--- a/src/structure/settings.html
+++ b/src/structure/settings.html
@@ -85,40 +85,45 @@
                             <input type="checkbox" class="custom-control-input" id=env-center>
                             <label class="custom-control-label" for=env-center title="center automatically structure or environment in the viewport" style="cursor: help;">center</label>
                         </div>
-
-                        <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                               <label class="input-group-text" for=env-cutoff>cutoff</label>
-                             </div>
-                             <input class="form-control" id=env-cutoff type="number" min="0" max= "50" step="0.1">
+                        <button class="btn btn-sm btn-secondary chsp-settings-extra-env-open" type="button" data-toggle="collapse" data-target="#chsp-extra-env" id=chsp-env-more>
+                            more options
+                        </button>
+                        <div class="collapse chsp-map-extra-env" id=chsp-extra-env>
+                            <div class="chsp-settings-environments">
+                                <div> </div>                                
+                                <div class="input-group input-group-sm">
+                                    <div class="input-group-prepend">
+                                       <label class="input-group-text" for=env-cutoff>cutoff</label>
+                                     </div>
+                                     <input class="form-control" id=env-cutoff type="number" min="0" max= "50" step="0.1">
+                                </div>
+                                <button class="btn btn-sm btn-light" id=env-reset>reset</button>
+                                <div>
+                                    <span style="vertical-align: middle">Background atoms</span>
+                                </div>
+                                <div class="input-group input-group-sm">
+                                    <div class="input-group-prepend">
+                                       <label class="input-group-text" for=env-bg-color>color</label>
+                                     </div>
+                                     <select id=env-bg-color class="custom-select">
+                                         <option value="CPK">CPK</option>
+                                         <option value="grey">grey</option>
+                                     </select>
+                                </div>
+                                <div class="input-group input-group-sm">
+                                    <div class="input-group-prepend">
+                                        <label class="input-group-text" for=env-bg-style>style</label>
+                                      </div>
+                                      <select id=env-bg-style class="custom-select">
+                                          <option value="licorice">licorice</option>
+                                          <option value="ball-stick">ball and stick</option>
+                                          <option value="hide">hide</option>
+                                      </select>
+                                </div>
+                            </div>                        
                         </div>
-                        <button class="btn btn-sm btn-light" id=env-reset>reset</button>
                     </div>
-                    <div style="margin-bottom: 0.8em;"></div>
-                    <div class="chsp-settings-environments-bg">
-                        <div>
-                            <span style="vertical-align: middle">Background atoms</span>
-                        </div>
-                        <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                               <label class="input-group-text" for=env-bg-color>color</label>
-                             </div>
-                             <select id=env-bg-color class="custom-select">
-                                 <option value="CPK">CPK</option>
-                                 <option value="grey">grey</option>
-                             </select>
-                        </div>
-                        <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for=env-bg-style>style</label>
-                              </div>
-                              <select id=env-bg-style class="custom-select">
-                                  <option value="licorice">licorice</option>
-                                  <option value="ball-stick">ball and stick</option>
-                                  <option value="hide">hide</option>
-                              </select>
-                        </div>
-                    </div>
+                    <div style="margin-bottom: 0.8em;"></div>                    
                 </div>
 
                 <div style="margin-bottom: 1.5em;"></div>

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -619,7 +619,8 @@ export class JSmolWidget {
         // on a single page
         template.innerHTML = HTML_SETTINGS
             .replace(/id=(.*?) /g, (_: string, id: string) => `id=${this.guid}-${id} `)
-            .replace(/for=(.*?) /g, (_: string, id: string) => `for=${this.guid}-${id} `);
+            .replace(/for=(.*?) /g, (_: string, id: string) => `for=${this.guid}-${id} `)
+            .replace(/data-target=#(.*?) /g, (_: string, id: string) => `data-target=#${this.guid}-${id} `);
 
         this._settingsModal = template.content.firstChild! as HTMLElement;
         document.body.appendChild(this._settingsModal);
@@ -804,18 +805,21 @@ export class JSmolWidget {
         const wireframe = `wireframe ${settings.bonds.value ? '0.15' : 'off'}`;
         const spacefill = `spacefill ${settings.spaceFilling.value ? '80%' : '23%'}`;
 
-        let commands = '';
+        let commands = '';        
         if (this._highlighted === undefined || !settings.environments.activated.value) {
             commands += 'select all;';
+        	commands += 'centerAt average;';
             commands += 'hide none;';
             commands += 'color atoms cpk; color atoms opaque;';
             commands += `dots off; ${wireframe}; ${spacefill};`;
         } else {
-            // center of the environment
+            // center of the environment (or structure)
             if (settings.environments.center.value) {
-                commands += `select @${this._highlighted + 1};`;
-            	commands += 'centerAt average;';
+                commands += `select @${this._highlighted + 1};`;            
+            } else {
+                commands += 'select all;'
             }
+            commands += 'centerAt average;';
 
             // Atoms not in the environment
             commands += 'select all;';


### PR DESCRIPTION
Also rearranged the environment options to make space for the centering switch.
Fixes #23 - all in all it is both simpler and better to have this applied automatically on environment switch than to have a button that one has to click manually.