### PR TITLE
Remove usage of any

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -286,6 +286,12 @@
       "integrity": "sha1-mtvBKVBYKqZerXa//fOf4MJ6PAI=",
       "dev": true
     },
+    "@types/tmp": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
+      "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+      "dev": true
+    },
     "@types/uglify-js": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "npm run lint",
     "build": "webpack --mode production",
-    "download-example-input": "node ./utils/download-example-input.js",
+    "download-example-input": "ts-node ./utils/download-example-input.ts",
     "api-docs": "typedoc",
     "start": "webpack-dev-server -d --content-base ./app",
     "merge-dts": "dts-bundle --name chemiscope --main dist/src/index.d.ts --baseDir dist --out chemiscope.d.ts --removeSource",
@@ -27,6 +27,7 @@
     "@types/markdown-it": "0.0.9",
     "@types/node": "^13.13.9",
     "@types/plotly.js": "^1.50.12",
+    "@types/tmp": "^0.2.0",
     "@types/webpack": "^4.41.13",
     "css-loader": "^3.5.3",
     "dts-bundle": "^0.7.3",

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -151,24 +151,30 @@ export type JsObject = Record<string, unknown>;
  * required properties to be a dataset.
  */
 export function validateDataset(o: JsObject) {
-    if (!('meta' in o && typeof o.meta === 'object' && o.meta !== null)) {
-        throw Error('missing "meta" key in dataset');
+    if (!('meta' in o)) {
+        throw Error('missing "meta" key in the dataset');
+    } else if (!(typeof o.meta === 'object' && o.meta !== null)) {
+        throw Error('"meta" must be an object in the dataset');
     }
     checkMetadata(o.meta as JsObject);
 
-    if (!('structures' in o && Array.isArray(o.structures))) {
-        throw Error('missing "structures" key in dataset');
+    if (!('structures' in o)) {
+        throw Error('missing "structures" key in the dataset');
+    } else if (!(Array.isArray(o.structures))) {
+        throw Error('"structures" must be an array in the dataset');
     }
     const [structureCount, envCount] = checkStructures(o.structures);
 
-    if (!('properties' in o && typeof o.properties === 'object' && o.properties !== null)) {
-        throw Error('missing "properties" key in dataset');
+    if (!('properties' in o)) {
+        throw Error('missing "properties" key in then dataset');
+    } else if (!(typeof o.properties === 'object' && o.properties !== null)) {
+        throw Error('"properties" must be an object in the dataset');
     }
     checkProperties(o.properties as Record<string, JsObject>, structureCount, envCount);
 
     if ('environments' in o) {
         if (!Array.isArray(o.environments)) {
-            throw Error('"environments" must be an array in dataset');
+            throw Error('"environments" must be an array in the dataset');
         }
 
         if (o.environments.length !== envCount) {
@@ -179,34 +185,36 @@ export function validateDataset(o: JsObject) {
 }
 
 function checkMetadata(o: JsObject) {
-    if (!('name' in o && typeof o.name === 'string')) {
-        throw Error('missing "meta.name" key in dataset');
+    if (!('name' in o)) {
+        throw Error('missing "meta.name" key in the dataset');
+    } else if (typeof o.name !== 'string') {
+        throw Error('"meta.name" must be a string in the dataset');
     }
 
     if ('description' in o && typeof o.description !== 'string') {
-        throw Error('"meta.description" should be a string in dataset');
+        throw Error('"meta.description" should be a string in the dataset');
     }
 
     if ('authors' in o) {
         if (!Array.isArray(o.authors)) {
-            throw Error('"meta.authors" must be an array in dataset');
+            throw Error('"meta.authors" must be an array in the dataset');
         }
 
         for (const a of o.authors) {
             if (typeof a !== 'string') {
-                throw Error('"meta.authors" must be an array of strings in dataset');
+                throw Error('"meta.authors" must be an array of strings in the dataset');
             }
         }
     }
 
     if ('references' in o) {
         if (!Array.isArray(o.references)) {
-            throw Error('"meta.references" must be an array in dataset');
+            throw Error('"meta.references" must be an array in the dataset');
         }
 
         for (const a of o.references) {
             if (typeof a !== 'string') {
-                throw Error('"meta.references" must be an array of strings in dataset');
+                throw Error('"meta.references" must be an array of strings in the dataset');
             }
         }
     }

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -102,7 +102,7 @@ export interface UserStructure {
      * [[StructureViewer.loadStructure]] must be set to be able to load this
      * data.
      */
-    data: any;
+    data: unknown;
 }
 
 /** Possible types of properties: full structure property, or atomic property */

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import {PropertiesMap} from './map';
 import {MetadataPanel} from './metadata';
 import {StructureViewer} from './structure';
 
-import {checkDataset, Dataset, Structure} from './dataset';
+import {Dataset, JsObject, Structure, validateDataset} from './dataset';
 import {addWarningHandler, EnvironmentIndexer} from './utils';
 
 // tslint:disable-next-line: no-var-requires
@@ -50,7 +50,7 @@ export interface Config {
 /** @hidden
  * Check if `o` contains all the expected fields to be a [[Config]].
  */
-function checkConfig(o: any) {
+function validateConfig(o: JsObject) {
     if (!('meta' in o && typeof o.meta === 'string')) {
         throw Error('missing "meta" key in chemiscope config');
     }
@@ -76,7 +76,7 @@ function checkConfig(o: any) {
         return !!(obj && obj.constructor && obj.call && obj.apply);
     };
 
-    if ('loadStructure' in o && !isFunction(o.loadStructure)) {
+    if ('loadStructure' in o && o.loadStructure !== undefined && !isFunction(o.loadStructure)) {
         throw Error('"loadStructure" should be a function in chemiscope config');
     }
 }
@@ -113,8 +113,8 @@ class DefaultVisualizer {
     // the constructor is private because the main entry point is the static
     // `load` function
     private constructor(config: Config, dataset: Dataset) {
-        checkConfig(config);
-        checkDataset(dataset);
+        validateConfig(config as unknown as JsObject);
+        validateDataset(dataset as unknown as JsObject);
 
         const mode = (dataset.environments === undefined) ? 'structure' : 'atom';
         this._indexer = new EnvironmentIndexer(mode, dataset.structures, dataset.environments);

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 
-import {Environment, isPositiveInteger, Structure, UserStructure} from '../dataset';
+import {Environment, isPositiveInteger, JsObject, Structure, UserStructure} from '../dataset';
 import {EnvironmentIndexer, Indexes, PositioningCallback} from '../utils';
 import {generateGUID, getByID, getNextColor, sendWarning} from '../utils';
 
@@ -76,22 +76,27 @@ function groupByStructure(n_structures: number, environments?: Environment[]): E
  * issue with `s` if any, or the empty string if `s` looks like a valid
  * structure.
  */
-function checkStructure(s: any): string {
+function checkStructure(s: JsObject): string {
     if (!('size' in s && typeof s.size === 'number' && isPositiveInteger(s.size))) {
         return 'missing "size" in structure';
     }
 
     for (const key of ['names', 'x', 'y', 'z']) {
-        if (!(key in s && s[key].length !== undefined)) {
-            return `missing '${name}' in structure`;
+        if (!(key in s)) {
+            return `missing "${name}" in structure`;
         }
-        if (s[key].length !== s.size) {
-            return `wrong size for '${name}' in structure, expected ${s.size}, got ${s[name].length}`;
+        const array = s[key];
+        if (!Array.isArray(array)) {
+            return `"${name}" must be an array in structure`;
+        }
+
+        if (array.length !== s.size) {
+            return `wrong size for "${name}" in structure, expected ${s.size}, got ${array.length}`;
         }
     }
 
     if ('cell' in s) {
-        if (s.cell.length !== 9) {
+        if (!(Array.isArray(s.cell) && s.cell.length === 9)) {
             return '"cell" must be an array of size 9 in structure';
         }
     }
@@ -330,7 +335,7 @@ export class StructureViewer {
     private _structureForJSmol(index: number): string {
         if (this._cachedStructures[index] === undefined) {
             const s = this.loadStructure(index, this._structures[index]);
-            const check = checkStructure(s);
+            const check = checkStructure(s as unknown as JsObject);
             if (check !== '') {
                 throw Error(
                     `got invalid object as structure: ${check}` + '\n' +

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 
-import {Environment, isPositiveInteger, JsObject, Structure, UserStructure} from '../dataset';
+import {checkStructure, Environment, JsObject, Structure, UserStructure} from '../dataset';
 import {EnvironmentIndexer, Indexes, PositioningCallback} from '../utils';
 import {generateGUID, getByID, getNextColor, sendWarning} from '../utils';
 
@@ -69,39 +69,6 @@ function groupByStructure(n_structures: number, environments?: Environment[]): E
     }
 
     return result;
-}
-
-/**
- * Check that the given object is a structure. Return a string describing the
- * issue with `s` if any, or the empty string if `s` looks like a valid
- * structure.
- */
-function checkStructure(s: JsObject): string {
-    if (!('size' in s && typeof s.size === 'number' && isPositiveInteger(s.size))) {
-        return 'missing "size" in structure';
-    }
-
-    for (const key of ['names', 'x', 'y', 'z']) {
-        if (!(key in s)) {
-            return `missing "${name}" in structure`;
-        }
-        const array = s[key];
-        if (!Array.isArray(array)) {
-            return `"${name}" must be an array in structure`;
-        }
-
-        if (array.length !== s.size) {
-            return `wrong size for "${name}" in structure, expected ${s.size}, got ${array.length}`;
-        }
-    }
-
-    if ('cell' in s) {
-        if (!(Array.isArray(s.cell) && s.cell.length === 9)) {
-            return '"cell" must be an array of size 9 in structure';
-        }
-    }
-
-    return '';
 }
 
 interface WidgetGridData {

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -10,7 +10,7 @@ import {EnvironmentIndexer, Indexes, PositioningCallback} from '../utils';
 import {generateGUID, getByID, getNextColor, sendWarning} from '../utils';
 
 import {structure2JSmol} from './jsmol';
-import {JSmolWidget} from './widget';
+import {JSmolWidget, LoadOptions} from './widget';
 
 import CLOSE_SVG from '../static/close.svg';
 import DUPLICATE_SVG from '../static/duplicate.svg';
@@ -129,7 +129,7 @@ export class StructureViewer {
      * The callback gets two parameter: the structure index (0-based); and the
      * full [[UserStructure]].
      */
-    public loadStructure: (index: number, structure: any) => Structure;
+    public loadStructure: (index: number, structure: unknown) => Structure;
 
     /// Root element containing the full viewer grid
     private _root: HTMLElement;
@@ -181,13 +181,13 @@ export class StructureViewer {
 
         this.loadStructure = (_, s) => {
             // check that the data does conform to the Structure interface
-            if (checkStructure(s) !== '') {
+            if (checkStructure(s as JsObject) !== '') {
                 throw Error(
                     'got custom data for this structure, but no custom loadStructure callback\n' +
                     `the object was ${JSON.stringify(s)}`,
                 );
             } else {
-                return s;
+                return s as Structure;
             }
         };
 
@@ -223,10 +223,10 @@ export class StructureViewer {
 
         const widget = data.widget;
         if (data.current.structure !== indexes.structure) {
-            const options = {
+            const options: Partial<LoadOptions> = {
                 packed: false,
                 trajectory: true,
-            } as any;
+            };
             assert(indexes.structure < this._structures.length);
 
             if (this._environments !== undefined) {

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -85,7 +85,7 @@ export interface Position {
 }
 
 /** Possible options passed to `JSmolWidget.load` */
-export interface LoadOption {
+export interface LoadOptions {
     /** Supercell to display (default: [1, 1, 1]) */
     supercell: [number, number, number];
     /** Should we display a packed cell (default: false) */
@@ -373,7 +373,7 @@ export class JSmolWidget {
      *             command](https://chemapps.stolaf.edu/jmol/docs/#load).
      * @param options options for the new structure
      */
-    public load(data: string, options: Partial<LoadOption> = {}) {
+    public load(data: string, options: Partial<LoadOptions> = {}) {
         if (data === '\'\'' || data === '""') {
             throw Error('invalid use of JSmolWidget.load to reload data');
         }

--- a/src/typing.d.ts
+++ b/src/typing.d.ts
@@ -35,11 +35,11 @@ declare module 'jsmol' {
      * Declaration of the functions available on the Jmol global object
      */
     export interface JmolObject {
-        setDocument(doc: any): void;
+        setDocument(doc: boolean): void;
         getApplet(htmlId: string, info: Partial<JmolInfo>): JSmolApplet;
         script(applet: JSmolApplet, commands: string): void;
         getAppletHtml(applet: JSmolApplet): string;
-        evaluateVar(applet: JSmolApplet, commands: string): any;
+        evaluateVar(applet: JSmolApplet, commands: string): unknown;
     }
 
     global {

--- a/utils/download-example-input.ts
+++ b/utils/download-example-input.ts
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const tmp = require('tmp');
-const childProcess = require('child_process');
+import * as fs from 'fs';
+import * as tmp from 'tmp';
+import * as childProcess from 'child_process';
 
 const tmpdir = tmp.dirSync({unsafeCleanup: true});
 const checkout = tmpdir.name + '/chemiscope';


### PR DESCRIPTION
While preparing the code to use eslint instead of the [deprecated tslint](https://medium.com/palantir/tslint-in-2019-1a144c2317a9), I found a few potential ameliorations.

The main one consist in using `Record<string, unknown>` and `unknown` in general instead of `any`. This means the compiler will ensure we check the type/values before using them.