### PR TITLE
Fix download-example-input if /tmp is on a different partition

### DIFF
--- a/utils/download-example-input.ts
+++ b/utils/download-example-input.ts
@@ -1,23 +1,27 @@
-import * as fs from 'fs';
-import * as tmp from 'tmp';
 import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tmp from 'tmp';
 
-const tmpdir = tmp.dirSync({unsafeCleanup: true});
-const checkout = tmpdir.name + '/chemiscope';
+const tmpdir = tmp.dirSync({
+    prefix: '.tmp',
+    tmpdir: path.join(__dirname, '..'),
+    unsafeCleanup: true,
+});
 
 childProcess.execSync(
     'git clone https://github.com/cosmo-epfl/chemiscope' +
-    ' --depth=1 ' + ' --branch=gh-pages ' + checkout
+    ' --depth=1 ' + ' --branch=gh-pages ' + tmpdir.name,
 );
 
 for (const file of ['CSD-500.json.gz', 'Arginine-Dipeptide.json.gz', 'Qm7b.json.gz', 'Azaphenacenes.json.gz', 'Zeolites.json.gz']) {
-    fs.renameSync(`${checkout}/${file}`, `./app/${file}`);
+    fs.renameSync(`${tmpdir.name}/${file}`, `./app/${file}`);
 }
 
 fs.mkdirSync('./app/structures/', {recursive: true});
-for (let i=0; i<523; i++) {
-    const file = `Azaphenacenes-${i}.json`
-    fs.renameSync(`${checkout}/structures/${file}`, `./app/structures/${file}`);
+for (let i = 0; i < 523; i++) {
+    const file = `Azaphenacenes-${i}.json`;
+    fs.renameSync(`${tmpdir.name}/structures/${file}`, `./app/structures/${file}`);
 }
 
 tmpdir.removeCallback();


### PR DESCRIPTION
Fix #47 