### PR TITLE
Feat/pin refactor

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -22,9 +22,9 @@ bibliography: paper.bib
 
 # Summary
 
-The number of different materials or molecules that can created by combining
+The number of materials or molecules that can be created by combining
 different chemical elements in various proportions and spatial arrangements is
-enormous. We can use computational chemistry to generate databases containing
+enormous. Computational chemistry can be used to generate databases containing
 billions of potential structures [@Ruddigkeit2012], and predict some of the
 associated properties [@Montavon2013; @Ramakrishnan2014]. Unfortunately, the
 very large number of structures makes exploring such database — to understand
@@ -57,11 +57,11 @@ descriptors can be very high dimensional, it can be convenient to apply a
 dimensionality reduction algorithm that maps them to a lower-dimensional space
 for easier visualization. For example the sketchmap algorithm [@Ceriotti2011]
 was used with the Smooth Overlap of Atomic Positions descriptor [@Bartok2013] to
-generate the visualization above. The right panel displays the three-dimensional
-structure of the chemical entities, possibly including periodic repetition for
-crystals. Visualizing the chemical structure can help finding an intuitive
-rationalization of the layout of the dataset and the structure-property
-relations.
+generate the visualization figure 1. The right panel displays the
+three-dimensional structure of the chemical entities, possibly including
+periodic repetition for crystals. Visualizing the chemical structure can help
+finding an intuitive rationalization of the layout of the dataset and the
+structure-property relations.
 
 Whereas similar tools [@Gong2013; @Gutlein2014; @Probst2017; @ISV] only allow
 visualizing maps and structures in which each data point corresponds to a
@@ -74,7 +74,7 @@ machine-learning schemes that decompose properties into atom-centred
 contributions [@Behler2007; @Bartok2010]
 
 
-![Database of chemical shielding [@Paruzzo2018] in chemiscope showing the use of a 3D plot and atomic environments highlighting](./screenshot-3d.png)
+![Database of chemical shieldings [@Paruzzo2018] in chemiscope demonstrating the use of a 3D plot and atomic environments highlighting](./screenshot-3d.png)
 
 Chemiscope took strong inspiration from a previous similar graphical software,
 the interactive sketchmap visualizer [@ISV]. This previous software was used in
@@ -90,20 +90,20 @@ interactivity. It uses [Plotly.js](https://plot.ly/javascript/) to render and
 animate 2D and 3D plots; and the JavaScript version of [Jmol](http://jmol.org/)
 to display atomic structures. The visualization is fast enough to be used with
 datasets containing up to a million points, reacting to user input within a few
-hundred milliseconds in the default 2D mode. More elaborate visualization are
+hundred milliseconds in the default 2D mode. More elaborate visualizations are
 slower, while still handling 100k points easily.
 
 The use of web technologies makes chemiscope usable from different operating
 systems without the need to develop, maintain and package the code for each
-operating system. It also mean that we can provide an online service at
+operating system. It also means that we can provide an online service at
 http://chemiscope.org allowing users to visualize their own dataset without
-installing anything. Chemiscope is implemented as library of re-usable
+any local installation. Chemiscope is implemented as library of re-usable
 components linked together via callbacks. This makes it easy to modify the
 default interface to generate more elaborate visualizations: for example
 displaying multiple maps generated with different parameters of a dimensionality
 reduction algorithm. Chemiscope can also be distributed in a standalone mode,
 where the code and a predefined dataset are merged together as a single HTML
-file. This standalone mode is useful for archival purposes, for example in as
+file. This standalone mode is useful for archival purposes, for example as
 supplementary information for a published article; and for use in corporate
 environments with sensitive datasets.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,8 +133,9 @@ class DefaultVisualizer {
             config.map,
             this._indexer,
             dataset.properties,
-            this.structure.active,
         );
+
+        this.map.active = this.structure.active;
 
         if (config.loadStructure !== undefined) {
             this.structure.loadStructure = config.loadStructure;

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,14 @@ class DefaultVisualizer {
           this.structure.removeWidget(removedGUID);
         };
 
+        this.structure.activate = (activeGUID) => {
+          this.map.active = activeGUID;
+        };
+
+        this.map.activate = (activeGUID) => {
+          this.structure.active = activeGUID;
+        };
+
         const initial = {environment: 0, structure: 0, atom: 0};
         this.structure.show(initial);
         this.info.show(initial);

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ class DefaultVisualizer {
         };
 
         this.structure.onremove = (removedGUID) => {
-          this.map.removeMarker(removedGUID, true);
+          this.map.removeMarker(removedGUID);
         };
 
         this.map.onremove = (removedGUID) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,14 @@ class DefaultVisualizer {
             this.structure.show(indexes, selectedGUID);
         };
 
+        this.structure.onremove = (removedGUID) => {
+          this.map.removeMarker(removedGUID, true);
+        };
+
+        this.map.onremove = (removedGUID) => {
+          this.structure.removeWidget(removedGUID);
+        };
+
         const initial = {environment: 0, structure: 0, atom: 0};
         this.structure.show(initial);
         this.info.show(initial);

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,8 @@ class DefaultVisualizer {
             this.structure.loadStructure = config.loadStructure;
         }
 
-        this.structure.onselect = (indexes, selectedGUID) => {
-            this.map.select(indexes, selectedGUID);
+        this.structure.onselect = (indexes) => {
+            this.map.select(indexes);
             if (indexes.structure > 0 && indexes.environment > 0) {
               this.info.show(indexes);
             }
@@ -155,9 +155,9 @@ class DefaultVisualizer {
         this.info.startStructurePlayback = (advance) => this.structure.structurePlayback(advance);
         this.info.startAtomPlayback = (advance) => this.structure.atomPlayback(advance);
 
-        this.map.onselect = (indexes, selectedGUID) => {
+        this.map.onselect = (indexes) => {
             this.info.show(indexes);
-            this.structure.show(indexes, selectedGUID);
+            this.structure.show(indexes);
         };
 
         this.structure.onremove = (removedGUID) => {

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -329,7 +329,9 @@ export class PropertiesMap {
         assert(markerData !== undefined);
 
         /// Sets the active marker on this map
-        if (markerData.current === undefined || indexes.environment !== markerData.current ) {
+        /// default of markerData.current is -1 so that currents of value 0 are
+        /// still updated
+        if (markerData.current < 0 || indexes.environment !== markerData.current ) {
             markerData.current = indexes.environment;
             this._updateSelectedMarker(selectedGUID, markerData);
         }
@@ -1439,7 +1441,7 @@ export class PropertiesMap {
      * @param  addedGUID unique string identifier of the marker to add
      * @param  index     numeric index of the structure (with respect to dataset) to show
      */
-    private _addMarker(addedGUID: string, index: number = 0): void {
+    private _addMarker(addedGUID: string, index: number= -1): void {
         if (!this._selected.has(addedGUID)) {
             const activeButton = getByID(`chsp-activate-${addedGUID}`);
             const marker = document.createElement('div');
@@ -1454,7 +1456,7 @@ export class PropertiesMap {
             marker.style.backgroundColor = color;
             const newMarkerData = {
                                       color : color,
-                                      current: Math.max(0, index),
+                                      current: index,
                                       marker: marker,
                                   };
             this._selected.set(addedGUID, newMarkerData);

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -199,8 +199,10 @@ interface MarkerData {
  */
 export class PropertiesMap {
     /** Callback fired when the plot is clicked and a new point is selected */
-    public onselect: (indexes: Indexes, selectedGUID?: string) => void;
+    public onselect: (indexes: Indexes) => void;
+    /** Callback fired when a guid is removed from the map */
     public onremove: (removedGUID: string) => void;
+    /** Callback fired when a new active marker is designated */
     public activate: (activeGUID: string) => void;
 
     /**

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -201,6 +201,7 @@ export class PropertiesMap {
     /** Callback fired when the plot is clicked and a new point is selected */
     public onselect: (indexes: Indexes, selectedGUID?: string) => void;
     public onremove: (removedGUID: string) => void;
+    public activate: (activeGUID: string) => void;
 
     /**
      * Callback to get the initial positioning of the settings modal.
@@ -263,6 +264,7 @@ export class PropertiesMap {
         this._indexer = indexer;
         this.onselect = () => {};
         this.onremove = () => {};
+        this.activate = () => {};
         this._selected = new Map();
 
         this._root = getByID(id);
@@ -382,7 +384,7 @@ export class PropertiesMap {
         assert(markerData !== undefined);
 
         const indexes = this._indexer.from_environment(markerData.current);
-        this.onselect(indexes, this._active);
+        this.activate(this.active);
     }
 
     /**

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -953,7 +953,7 @@ export class PropertiesMap {
                 this._indexer.from_environment(event.points[0].pointNumber);
 
             this.select(indexes, this._active);
-            this.onselect(indexes, this._active);
+            this.onselect(indexes);
         });
         this._plot.on('plotly_afterplot', () => this._afterplot());
 
@@ -1414,7 +1414,7 @@ export class PropertiesMap {
               marker.style.right = `${plotWidth - x}px`;
           }
           const indexes = this._indexer.from_environment(selected);
-          this.onselect(indexes, selectedGUID);
+          this.onselect(indexes);
     }
 
     private _updateAllMarkers() {

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -405,26 +405,16 @@ export class PropertiesMap {
     /**
      * Removes a marker from the map.
      *
-     * The parameter deleteFromGUIDs pertains to removing the guid from the guid
-     * list. This is *not* the same as the `force` parameter in
-     * `structure._removeWidget`. One may want to remove a marker when switching
-     * from 2D --> 3D but retain the information.
-     *
      * @param  removedGUID     unique string identifier of the marker to remove
-     * @param  deleteFromGUIDs boolean, if false keep the data of the marker stored
      */
-    public removeMarker(removedGUID: string, deleteFromGUIDs: boolean = true): void {
+    public removeMarker(removedGUID: string): void {
         const marker = document.getElementById(`chsp-selected-${removedGUID}`);
         if (marker !== null) {
             if (marker.parentNode !== null) {
                 marker.parentNode.removeChild(marker);
             }
 
-            // This will be false when going from 2D --> 3D as we want
-            // to remove all markers, but keep their information stored
-            if (deleteFromGUIDs) {
-                this._selected.delete(removedGUID);
-            }
+            this._selected.delete(removedGUID);
 
             if (this._active === removedGUID) {
                 assert(this._selected.size > 0);
@@ -433,6 +423,19 @@ export class PropertiesMap {
             this.onremove(removedGUID);
         }
     }
+
+    /**
+     * Function to hide the marker when switching from 2D to 3D
+     */
+    private _hideMarker(hiddenGUID: string): void {
+      const marker = document.getElementById(`chsp-selected-${hiddenGUID}`);
+      if (marker !== null) {
+          if (marker.parentNode !== null) {
+              marker.parentNode.removeChild(marker);
+          }
+      }
+    }
+
     /** Forward to Ploty.restyle */
     private _restyle(data: Partial<Data>, traces?: number | number[]) {
         Plotly.restyle(this._plot, data, traces).catch((e) => setTimeout(() => { throw e; }));
@@ -1273,7 +1276,7 @@ export class PropertiesMap {
 
         const cachedActive = this.active;
         for (const [guid, markerData] of this._selected.entries()) {
-            this.removeMarker(guid, false);
+            this._hideMarker(guid);
             this._updateSelectedMarker(guid, markerData);
         }
         this.active = cachedActive;

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1159,7 +1159,7 @@ export class PropertiesMap {
             // default to 0 (i.e. circles)
             return this._selectTrace<string | string[]>('circle', 'circle', trace);
         }
-        assert(this._selected.size > 0);
+
         const values = this._property(this._settings.symbol.value).values;
         const markerData = this._selected.get(this.active);
         assert(markerData !== undefined);

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -350,10 +350,12 @@ export class PropertiesMap {
     public get active() {
       if (this._selected.size > 0) {
         if (this._active === undefined) {
-        this.active = this._selected.keys().next().value;
-        return this._selected.keys().next().value;
-        } else { return this._active; }
-      } else {return ''; }
+            this.active = this._selected.keys().next().value;
+            return this._selected.keys().next().value;
+        } else {
+            return this._active; }
+      } else {
+            return ''; }
     }
     /**
      * Function to set the active marker for communicating with the structure

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -327,7 +327,7 @@ export class PropertiesMap {
         /// Sets the active marker on this map
         /// default of markerData.current is -1 so that currents of value 0 are
         /// still updated
-        if (markerData.current < 0 || indexes.environment !== markerData.current ) {
+        if (markerData.current === 0 || indexes.environment !== markerData.current ) {
             markerData.current = indexes.environment;
             this._updateSelectedMarker(selectedGUID, markerData);
         }
@@ -1451,7 +1451,7 @@ export class PropertiesMap {
      * @param  addedGUID unique string identifier of the marker to add
      * @param  index     numeric index of the structure (with respect to dataset) to show
      */
-    private _addMarker(addedGUID: string, index: number= -1): void {
+    private _addMarker(addedGUID: string, index: number= 0): void {
         if (!this._selected.has(addedGUID)) {
             const activeButton = getByID(`chsp-activate-${addedGUID}`);
             const marker = document.createElement('div');

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -254,12 +254,10 @@ export class PropertiesMap {
      * @param indexer    [[EnvironmentIndexer]] used to translate indexes from
      *                   environments index to structure/atom indexes
      * @param properties properties to be displayed
-     * @param starterGUID if synchronized with a StructureViewer, the GUID of the first structure viewer cell
      */
     constructor(id: string,
                 indexer: EnvironmentIndexer,
                 properties: {[name: string]: Property},
-                starterGUID?: string,
                 ) {
         this._indexer = indexer;
         this.onselect = () => {};
@@ -279,14 +277,6 @@ export class PropertiesMap {
         this._root.appendChild(this._plot);
 
         this._data = new MapData(properties);
-
-        if (starterGUID !== undefined) {
-            this._addMarker(starterGUID);
-            this.active = starterGUID;
-        } else {
-            this._addMarker(generateGUID());
-            this.active = this._selected.keys().next().value;
-        }
 
         this._insertSettingsHTML();
         this._colorReset = getByID<HTMLButtonElement>('chsp-color-reset');

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -299,7 +299,10 @@ export class PropertiesMap {
         };
     }
 
-    /** Change the selected environment to the one with the given `indexes` */
+    /** Change the environment corresponding to the `selectGUID` in
+     * this._selected to the one with the given `indexes`
+     * if selectedGUID is not defined, it will default to the active GUID, if available
+     */
     public select(indexes: Indexes, selectedGUID?: string) {
         // Plotly.restyle fires the plotly_click event, so ensure we only run
         // the update once.

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -360,7 +360,9 @@ export class PropertiesMap {
             return;
         }
 
-        assert(this._selected.has(activeGUID));
+        if (!this._selected.has(activeGUID)) {
+          this._addMarker(activeGUID);
+        }
 
         if (!this._is3D()) {
             // if we are in 2D we need to update the visuals

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -175,6 +175,9 @@ export class StructureViewer {
         root.appendChild(this._root);
 
         this._setupGrid(1);
+
+        // Double check the grid has been made properly
+        assert(this._viewers.size > 0);
         this.active = this._viewers.keys().next().value;
         this._active = this.active;
 

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -303,11 +303,10 @@ export class StructureViewer {
 
     /*
      * Removes a widget from the structure viewer grid.
-     * The parameter force pertains to removing the *only* widget in the grid,
-     * which should only be done when changing datasets.
+     * Will not remove a widget if it is the last one in the structure viewer
      */
-    public removeWidget(removedGUID: string, force: boolean = false) {
-        if (this._viewers.size > 1 || force === true) {
+    public removeWidget(removedGUID: string) {
+        if (this._viewers.size > 1) {
             if (this._viewers.has(removedGUID)) {
 
               const widgetRoot = getByID(`chsp-${removedGUID}`);

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -84,7 +84,9 @@ interface WidgetGridData {
 export class StructureViewer {
     /** Callback used when the user select an environment */
     public onselect: (indexes: Indexes) => void;
+    /** Callback fired when a guid is removed from the map */
     public onremove: (removedGUID: string) => void;
+    /** Callback fired when a new active marker is designated */
     public activate: (activeGUID: string) => void;
 
     /**

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -83,7 +83,7 @@ interface WidgetGridData {
  */
 export class StructureViewer {
     /** Callback used when the user select an environment */
-    public onselect: (indexes: Indexes, selectedGUID?: string) => void;
+    public onselect: (indexes: Indexes) => void;
     public onremove: (removedGUID: string) => void;
 
     /**
@@ -235,7 +235,7 @@ export class StructureViewer {
                 const structure = (current.structure + 1) % this._indexer.structuresCount();
                 const indexes = this._indexer.from_structure_atom(structure, 0);
                 this.show(indexes);
-                this.onselect(indexes, this.active);
+                this.onselect(indexes);
                 // continue playing until the advance callback returns false
                 this.structurePlayback(advance);
 
@@ -258,7 +258,7 @@ export class StructureViewer {
                 const atom = (current.atom! + 1) % this._indexer.atomsCount(structure);
                 const indexes = this._indexer.from_structure_atom(structure, atom);
                 this.show(indexes);
-                this.onselect(indexes, this.active);
+                this.onselect(indexes);
                 // continue playing until the advance callback returns false
                 this.atomPlayback(advance);
             }
@@ -397,7 +397,6 @@ export class StructureViewer {
             const atom = data.current.atom;
             indexes = this._indexer.from_structure_atom(structure, atom);
         }
-        this.onselect(indexes, this.active);
     }
 
     /**
@@ -488,9 +487,9 @@ export class StructureViewer {
                     // no new widget, probably because we already have MAX_WIDGETS
                     return;
                 }
-                assert(newGuid.length === 1);
-                this.show(index, newGuid[0]);
-                this.onselect(index, newGuid[0]);
+                assert(newGUID.length === 1);
+                this.show(index, newGUID[0]);
+                this.onselect(index);
             };
 
             cell.appendChild(duplicate);
@@ -544,6 +543,7 @@ export class StructureViewer {
             } else {
                 cellGUID = mapKeys.next().value;
             }
+
             let color = this._setupCell(cellGUID, colNum, rowNum);
             if (color === '') {
                 color = this._getNextColor();
@@ -577,7 +577,7 @@ export class StructureViewer {
                     assert(data !== undefined);
                     const atom_id = atom % widget.natoms()!;
                     const indexes = this._indexer.from_structure_atom(data.current.structure, atom_id);
-                    this.onselect(indexes, this.active);
+                    this.onselect(indexes);
                 };
 
                 const current = {atom: -1, structure: -1, environment: -1};

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -477,8 +477,8 @@ export class StructureViewer {
                     index = this._indexer.from_structure_atom(data.current.structure, data.current.atom);
                 }
 
-                const newGuid = this._setupGrid(this._viewers.size + 1);
-                if (newGuid.length === 0) {
+                const newGUID = this._setupGrid(this._viewers.size + 1);
+                if (newGUID.length === 0) {
                     // no new widget, probably because we already have MAX_WIDGETS
                     return;
                 }


### PR DESCRIPTION
Refactoring the pinning infrastructure with respect to #45 

- [x] Do not call select({-1, -1}, guid) to indicate removal
- [ ] instead add specific functions for each possible action: 
    - [ ] addPinned 
    - [x] removePinned
    - [x] changeActivePinned. 
- [x] Then select always act on the current active
- [x] only move the marker/change the structure
- [x] Remove the starterGUID parameter for PropertyMap constructor to allow using the map without a structure viewer. This should be easy to do after the above changes
- [ ] Extract code dealing with selected markers (things like classList.toggle('chsp-active-structure-marker', false)) to a separate HTMLMarker class doing all of this. 
- [ ] On a related note, src/map/map.ts is getting quite large, so we should try to extract functionalities and potentially move it out of this file.