### PR TITLE
Improve assertion messages

### DIFF
--- a/utils/webpack-assert-message.ts
+++ b/utils/webpack-assert-message.ts
@@ -1,0 +1,22 @@
+/**
+ * A webpack loader to use the assertion expression as error message if the
+ * assertion fails.
+ *
+ * ```
+ * assert(foo && bar.baz == "test");
+ * ```
+ * is transformed to
+ * ```
+ * assert(foo && bar.baz == "test", "foo && bar.baz == \"test\"");
+ * ```
+ *
+ * The replacement mechanism is not very robust since it is based on regex
+ * instead of a full AST, but it should be good enough to work with simple,
+ * single line assertions.
+ */
+export default function(source: string): string {
+    return source.replace(/assert\((.*)\)/g, (_, expr) => {
+        const escaped = expr.replace(/"/g, '\\"');
+        return `assert(${expr}, "${escaped}")`;
+    });
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -14,7 +14,7 @@ const config: webpack.Configuration = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' },
+            { test: /\.ts?$/, use: ['ts-loader', './utils/webpack-assert-message.ts'] },
             { test: /\.css?$/, use: ['style-loader', 'css-loader'] },
             { test: /\.html?$/, loader: 'html-loader', options: { minimize: true } },
             { test: /\.svg?$/, loader: 'html-loader', options: { minimize: true } },


### PR DESCRIPTION
Instead of showing `AssertionError: false === true`, show the expression used to generate the assertion, i.e. `AssertionError: tableRoot.tagName.toLowerCase() === 'div'`.

This was surprisingly easy to do once I figured out where to insert it in the webpack life cycle.