### PR TITLE
Do not include source maps in production mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chemiscope",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -313,6 +313,15 @@
         "@types/uglify-js": "*",
         "@types/webpack-sources": "*",
         "source-map": "^0.6.0"
+      }
+    },
+    "@types/webpack-merge": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-merge/-/webpack-merge-4.1.5.tgz",
+      "integrity": "sha512-cbDo592ljSHeaVe5Q39JKN6Z4vMhmo4+C3JbksOIg+kjhKQYN2keGN7dvr/i18+dughij98Qrsfn1mU9NgVoCA==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "*"
       }
     },
     "@types/webpack-sources": {
@@ -11005,6 +11014,15 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "scripts": {
     "test": "npm run lint",
-    "build": "webpack --mode production",
+    "build": "webpack --config webpack.prod.ts",
     "download-example-input": "ts-node ./utils/download-example-input.ts",
     "api-docs": "typedoc",
-    "start": "webpack-dev-server -d --content-base ./app",
+    "start": "webpack-dev-server --config webpack.dev.ts --content-base ./app",
     "merge-dts": "dts-bundle --name chemiscope --main dist/src/index.d.ts --baseDir dist --out chemiscope.d.ts --removeSource",
     "prepublishOnly": "rm -rf dist && npm run build && npm run merge-dts",
     "lint": "tslint -c tslint.json src/*.ts"
@@ -29,6 +29,7 @@
     "@types/plotly.js": "^1.50.12",
     "@types/tmp": "^0.2.0",
     "@types/webpack": "^4.41.13",
+    "@types/webpack-merge": "^4.1.5",
     "css-loader": "^3.5.3",
     "dts-bundle": "^0.7.3",
     "html-loader": "^1.1.0",
@@ -43,7 +44,8 @@
     "typescript": "^3.9.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0",
+    "webpack-merge": "^4.2.2"
   },
   "dependencies": {
     "markdown-it": "^10.0.0",

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 
 import {Property} from '../dataset';
 import {EnvironmentIndexer, HTMLSetting, Indexes, PositioningCallback, SettingGroup, SettingModificationOrigin} from '../utils';
-import {foreachSetting, generateGUID, getByID, makeDraggable, sendWarning} from '../utils';
+import {foreachSetting, getByID, makeDraggable, sendWarning} from '../utils';
 
 import Plotly from './plotly/plotly-scatter';
 import {Config, Data, Layout, PlotlyScatterElement} from './plotly/plotly-scatter';
@@ -398,7 +398,6 @@ export class PropertiesMap {
         const markerData = this._selected.get(this._active);
         assert(markerData !== undefined);
 
-        const indexes = this._indexer.from_environment(markerData.current);
         this.activate(this._active);
     }
 

--- a/src/map/plotly/plotly-scatter.js
+++ b/src/map/plotly/plotly-scatter.js
@@ -2,8 +2,9 @@
 // - plotly.js/lib/index-gl2d
 // - plotly.js/lib/index-gl3d
 //
-// Using this instead of the standard plotly build allow to shave 1.5 Mib from
-// the resulting minified JS.
+// Using this instead of the standard plotly build allow to shave ~2 Mib from
+// the resulting minified JS. Without this, chemiscope.min.js is ~3.5 Mib, with
+// this it is only 1.6 Mib.
 
 'use strict';
 

--- a/webpack.base.ts
+++ b/webpack.base.ts
@@ -6,12 +6,10 @@ import {execSync} from 'child_process';
 const GIT_VERSION = execSync('git describe --tags --dirty').toString().trim();
 
 const config: webpack.Configuration = {
-    devtool: 'inline-source-map',
     entry: {
         'chemiscope': './src/index.ts',
         'jsmol-widget': './src/structure/widget.ts',
     },
-    mode: 'development',
     module: {
         rules: [
             { test: /\.ts?$/, use: ['ts-loader', './utils/webpack-assert-message.ts'] },

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -1,0 +1,11 @@
+import webpack from 'webpack';
+import merge from 'webpack-merge';
+
+import base from './webpack.base';
+
+const config: webpack.Configuration = merge(base, {
+    devtool: 'inline-source-map',
+    mode: 'development',
+});
+
+export default config;

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -1,0 +1,10 @@
+import webpack from 'webpack';
+import merge from 'webpack-merge';
+
+import base from './webpack.base';
+
+const config: webpack.Configuration = merge(base, {
+    mode: 'production',
+});
+
+export default config;


### PR DESCRIPTION
They take ~9mb of additional space, making chemiscope.min.js 10.6Mb. After this PR, the minified build is back to 1.6Mb.