### PR TITLE
More refactoring of the pin functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,20 +161,20 @@ class DefaultVisualizer {
             this.structure.show(indexes);
         };
 
-        this.structure.onremove = (removedGUID) => {
-          this.map.removeMarker(removedGUID);
+        this.structure.onremove = (guid) => {
+            this.map.removeMarker(guid);
         };
 
-        this.map.onremove = (removedGUID) => {
-          this.structure.removeWidget(removedGUID);
+        this.map.onremove = (guid) => {
+            this.structure.removeWidget(guid);
         };
 
-        this.structure.activate = (activeGUID) => {
-          this.map.active = activeGUID;
+        this.structure.activate = (guid) => {
+            this.map.active = guid;
         };
 
-        this.map.activate = (activeGUID) => {
-          this.structure.active = activeGUID;
+        this.map.activate = (guid) => {
+            this.structure.active = guid;
         };
 
         const initial = {environment: 0, structure: 0, atom: 0};

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -387,8 +387,7 @@ export class PropertiesMap {
 
         } else {
             this._active = activeGUID;
-            const factor = this._settings.size.factor.value;
-            this._restyle({'marker.size': this._sizes(factor, 1)} as Data, 1);
+            this._restyle({'marker.size': this._sizes(1)} as Data, 1);
         }
 
         const markerData = this._selected.get(this._active);
@@ -677,15 +676,12 @@ export class PropertiesMap {
         };
 
         // ======= markers size
-        this._settings.size.property.onchange = () => {
-            const factor = this._settings.size.factor.value;
-            this._restyle({ 'marker.size': this._sizes(factor, 0) } as Data, 0);
+        const sizeChange = () => {
+            this._restyle({ 'marker.size': this._sizes(0) } as Data, 0);
         };
 
-        this._settings.size.factor.onchange = () => {
-            const factor = this._settings.size.factor.value;
-            this._restyle({ 'marker.size': this._sizes(factor, 0) } as Data, 0);
-        };
+        this._settings.size.property.onchange = sizeChange;
+        this._settings.size.factor.onchange = sizeChange;
     }
 
     /**
@@ -833,8 +829,7 @@ export class PropertiesMap {
 
         const colors = this._colors();
         const lineColors = this._lineColors();
-        // default value for the size factor is 50
-        const sizes = this._sizes(50);
+        const sizes = this._sizes();
         const symbols = this._symbols();
 
         const x = this._xValues();
@@ -1091,10 +1086,8 @@ export class PropertiesMap {
     /**
      * Get the values to use as marker size with the given plotly `trace`, or
      * all of them if `trace === undefined`.
-     *
-     * The size scaling parameter should be given in `sizeSliderValue`.
      */
-    private _sizes(sizeSliderValue: number, trace?: number): Array<number | number[]> {
+    private _sizes(trace?: number): Array<number | number[]> {
         // Transform the linear value from the slider into a logarithmic scale
         const logSlider = (value: number) => {
             const min_slider = 1;
@@ -1108,7 +1101,7 @@ export class PropertiesMap {
             return Math.exp(min_value + tmp * (value - min_slider));
         };
 
-        const userFactor = logSlider(sizeSliderValue);
+        const userFactor = logSlider(this._settings.size.factor.value);
 
         let values;
         if (this._settings.size.property.value !== '') {
@@ -1277,7 +1270,6 @@ export class PropertiesMap {
         this.active = cachedActive;
 
         // Change the data that vary between 2D and 3D mode
-        const factor = this._settings.size.factor.value;
         this._restyle({
             // transparency messes with depth sorting in 3D mode, even with
             // line width set to 0 ¯\_(ツ)_/¯
@@ -1285,7 +1277,7 @@ export class PropertiesMap {
             'marker.line.color': this._lineColors(),
             'marker.line.width': [0, 2],
             // size change from 2D to 3D
-            'marker.size': this._sizes(factor),
+            'marker.size': this._sizes(),
             'marker.sizemode': 'area',
         } as Data, [0, 1]);
 
@@ -1324,14 +1316,13 @@ export class PropertiesMap {
         this.active = cachedActive;
 
         // Change the data that vary between 2D and 3D mode
-        const factor = this._settings.size.factor.value;
         this._restyle({
             // transparency messes with depth sorting in 3D mode
             // https://github.com/plotly/plotly.js/issues/4111
             'marker.line.color': this._lineColors(),
             'marker.line.width': [1, 2],
             // size change from 2D to 3D
-            'marker.size': this._sizes(factor),
+            'marker.size': this._sizes(),
         } as Data, [0, 1]);
 
         this._relayout({
@@ -1394,10 +1385,9 @@ export class PropertiesMap {
                   symbols = get3DSymbol(0);
               }
 
-              const factor = this._settings.size.factor.value;
               this._restyle({
                   'marker.color': this._colors(1),
-                  'marker.size': this._sizes(factor, 1),
+                  'marker.size': this._sizes(1),
                   'marker.symbol': symbols,
                   'x': this._xValues(1),
                   'y': this._yValues(1),

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -425,18 +425,6 @@ export class PropertiesMap {
         }
     }
 
-    /**
-     * Function to hide the marker when switching from 2D to 3D
-     */
-    private _hideMarker(guid: GUID): void {
-      const marker = document.getElementById(`chsp-selected-${guid}`);
-      if (marker !== null) {
-          if (marker.parentNode !== null) {
-              marker.parentNode.removeChild(marker);
-          }
-      }
-    }
-
     /** Forward to Ploty.restyle */
     private _restyle(data: Partial<Data>, traces?: number | number[]) {
         Plotly.restyle(this._plot, data, traces).catch((e) => setTimeout(() => { throw e; }));
@@ -1270,8 +1258,8 @@ export class PropertiesMap {
         } as unknown as Data);
 
         const cachedActive = this.active;
-        for (const [guid, data] of this._selected.entries()) {
-            this._hideMarker(guid);
+        for (const data of this._selected.values()) {
+            data.marker.style.display = 'none';
             this._updateSelectedMarker(data);
         }
         this.active = cachedActive;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,8 @@
  * @module utils
  */
 
+import assert from 'assert';
+
 import {makeDraggable} from './draggable';
 import {DisplayMode, EnvironmentIndexer, Indexes} from './indexer';
 import {foreachSetting, HTMLSetting, SettingGroup, SettingModificationOrigin} from './settings';
@@ -18,10 +20,7 @@ import {addWarningHandler, sendWarning} from './warnings';
 export type PositioningCallback = (rect: DOMRect) => {top: number, left: number};
 
 const STANDARD_COLORS = [
-    'Red', 'Yellow', 'Green', 'Blue',
-    'Orange', 'Aqua', 'Purple', 'Teal',
-    'White', 'Gray', 'Black', 'Maroon',
-    'Olive', 'Silver', 'Lime', 'Navy', 'Fuchsia',
+    'red', 'yellow', 'green', 'blue', 'orange', 'aqua', 'purple', 'teal', 'silver',
 ];
 
 export function getNextColor(alreadyUsedColors: string[]) {
@@ -55,6 +54,43 @@ function getByID<HTMLType = HTMLElement>(id: string): HTMLType {
         throw Error(`unable to get element with id ${id}`);
     }
     return e as unknown as HTMLType;
+}
+
+export function enumerate<T>(iterable: Iterable<T>): Iterable<[number, T]> {
+    const iterator = function*() {
+        let index = 0;
+        for (const element of iterable) {
+            yield [index, element];
+            index++;
+        }
+    };
+
+    return {
+        [Symbol.iterator]: iterator,
+    } as Iterable<[number, T]>;
+}
+
+/**
+ * Get the first key of a Map, potentially excluding a specific key value.
+ *
+ * If `excluding` is specified and the first key is equal to `excluding`; the
+ * second key will be returned.
+ *
+ * @param map       the map where to look for keys
+ * @param excluding do not use this specific value if it is the first key
+ * @return the first or second key depending on `excluding`
+ */
+export function getFirstKey<K, V>(map: Map<K, V>, excluding?: K): K {
+    assert(map.size >= 1);
+    const keys = map.keys();
+    const first = keys.next().value;
+    if (excluding !== undefined) {
+        if (first === excluding) {
+            assert(map.size >= 2);
+            return keys.next().value;
+        }
+    }
+    return first;
 }
 
 export {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,14 +33,19 @@ export function getNextColor(alreadyUsedColors: string[]) {
     throw Error('required more colors than available');
 }
 
-function generateGUID(): string {
+/** Type to separate generic strings from GUID */
+declare const tag: unique symbol;
+export type GUID = string & {readonly [tag]: 'guid'};
+
+/** Generate a new GUID */
+function generateGUID(): GUID {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
         // tslint:disable-next-line:no-bitwise
         const r = Math.random() * 16 | 0;
         // tslint:disable-next-line:no-bitwise
         const v = c === 'x' ? r : (r & 0x3 | 0x8);
         return v.toString(16);
-    });
+    }) as GUID;
 }
 
 /** Get an HTML element by id */


### PR DESCRIPTION
Fix #56 

Continue working on #45: all of the communication between map & viewer grid now happen through public method & callback (no `getById`); and there are separated callback/methods for 

- adding a new pinned environment; 
- removing a pinned environment; 
- changing which pinned environment is the active one
- changing which environment is showed by the active viewer

All these methods exists on the viewer side, while the map only exposes the "change which env is showed" & "change the active viewer" since that's all the user can do with the map.
