### PR TITLE
Update depdencies and move ploty & markdown-it to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
       "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
+      "dev": true,
       "requires": {
         "matrix-camera-controller": "^2.1.1",
         "orbit-camera-controller": "^4.0.0",
@@ -43,7 +44,8 @@
     "@choojs/findup": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
-      "integrity": "sha1-rBPFmue+bh2mTeB3mgp/A9dWFaM=",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "dev": true,
       "requires": {
         "commander": "^2.15.1"
       }
@@ -52,6 +54,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
       "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
+      "dev": true,
       "requires": {
         "concat-stream": "~2.0.0",
         "minimist": "^1.2.5"
@@ -61,6 +64,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
           "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -72,6 +76,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -82,6 +87,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -91,37 +97,44 @@
     "@mapbox/geojson-types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha1-muz2QssA6rEIClfE+UmmW0pYRtY="
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
+      "dev": true
     },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "dev": true
     },
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha1-9gtqVaXY5e6Qg0fSzkJQsVED3I4="
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "dev": true
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
+      "dev": true
     },
     "@mapbox/tiny-sdf": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
-      "integrity": "sha1-FqIMRwdBv+kZHeszb0bhlNpKkf8="
+      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg==",
+      "dev": true
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
+      "dev": true
     },
     "@mapbox/vector-tile": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha1-06dMkEAtBuiexm3knsgX/1NAlmY=",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dev": true,
       "requires": {
         "@mapbox/point-geometry": "~0.1.0"
       }
@@ -129,12 +142,14 @@
     "@mapbox/whoots-js": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha1-SXxnoc71DRokWbpg8xXkSNKth/4="
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "dev": true
     },
     "@plotly/d3-sankey": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
-      "integrity": "sha1-3dUpDTsCxgA3ztAYoWJkSizO8zs=",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "dev": true,
       "requires": {
         "d3-array": "1",
         "d3-collection": "1",
@@ -144,7 +159,8 @@
     "@plotly/d3-sankey-circular": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
-      "integrity": "sha1-FdHgM34OSxE1vfDiGVyIrays4ac=",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "dev": true,
       "requires": {
         "d3-array": "^1.2.1",
         "d3-collection": "^1.0.4",
@@ -155,7 +171,8 @@
     "@turf/area": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
-      "integrity": "sha1-UO1jxw7yvbcpUjhPFZQxnZTzsFE=",
+      "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
+      "dev": true,
       "requires": {
         "@turf/helpers": "6.x",
         "@turf/meta": "6.x"
@@ -164,7 +181,8 @@
     "@turf/bbox": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
-      "integrity": "sha1-uWYHV3FHWUDuHBa+KhLPOJ5ukjo=",
+      "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
+      "dev": true,
       "requires": {
         "@turf/helpers": "6.x",
         "@turf/meta": "6.x"
@@ -173,7 +191,8 @@
     "@turf/centroid": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.0.2.tgz",
-      "integrity": "sha1-xOsWtLxgtpL3ThgJz5p8Sk9bocw=",
+      "integrity": "sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==",
+      "dev": true,
       "requires": {
         "@turf/helpers": "6.x",
         "@turf/meta": "6.x"
@@ -182,12 +201,14 @@
     "@turf/helpers": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha1-1v1+vmeC3ZyH3KVVm9pcSK5MODY="
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
+      "dev": true
     },
     "@turf/meta": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-      "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "dev": true,
       "requires": {
         "@turf/helpers": "6.x"
       }
@@ -195,13 +216,13 @@
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
-      "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
+      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
       "dev": true
     },
     "@types/d3": {
       "version": "3.5.43",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.43.tgz",
-      "integrity": "sha1-6bSZKBfgtsXvqn1uW7LO5Nc+q1g=",
+      "integrity": "sha512-t9ZmXOcpVxywRw86YtIC54g7M9puRh8hFedRvVfHKf5YyOP6pSxA0TvpXpfseXSCInoW4P7bggTrSDiUOs4g5w==",
       "dev": true
     },
     "@types/detect-indent": {
@@ -235,17 +256,24 @@
     "@types/linkify-it": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-2.1.0.tgz",
-      "integrity": "sha1-6j3WTEgFWXMReQth6HLL0e0s2AY=",
+      "integrity": "sha512-Q7DYAOi9O/+cLLhdaSvKdaumWyHbm7HAk/bFwwyTuU0arR5yyCeW5GOoqt4tJTpDRxhpx9Q8kQL6vMpuw9hDSw==",
       "dev": true
     },
     "@types/markdown-it": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-0.0.9.tgz",
-      "integrity": "sha1-pdVS+VIWxHjgonpazBso3P/Zic4=",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-10.0.1.tgz",
+      "integrity": "sha512-L1ibTdA5IUe/cRBlf3N3syAOBQSN1WCMGtAWir6mKxibiRl4LmpZM4jLz+7zAqiMnhQuAP1sqZOF9wXgn2kpEg==",
       "dev": true,
       "requires": {
-        "@types/linkify-it": "*"
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
       }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -260,15 +288,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.9.tgz",
-      "integrity": "sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==",
+      "version": "14.0.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.20.tgz",
+      "integrity": "sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A==",
       "dev": true
     },
     "@types/plotly.js": {
-      "version": "1.50.12",
-      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.50.12.tgz",
-      "integrity": "sha512-ZyXsV0XCGI/clfo+o04kQNY8SAFR/9k/eiSmooEtg9EENdpOo+Z74qQSYGkGlNWZcdDvFWpWdeOAM7BrJLn/LQ==",
+      "version": "1.50.14",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.50.14.tgz",
+      "integrity": "sha512-N1MrWw3DF06Xl+2eop6lBTvXeMMA4lnhqDbwtwnSX0IbeuK70fg+CTF4TORfHc65i4NUT5zk4YJjdC8a/DFcVQ==",
       "dev": true,
       "requires": {
         "@types/d3": "^3"
@@ -277,13 +305,13 @@
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-      "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
     },
     "@types/tapable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
-      "integrity": "sha1-mtvBKVBYKqZerXa//fOf4MJ6PAI=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+      "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
     },
     "@types/tmp": {
@@ -293,18 +321,18 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.2.tgz",
-      "integrity": "sha512-d6dIfpPbF+8B7WiCi2ELY7m0w1joD8cRW4ms88Emdb2w062NeEpbNCeWwVCgzLRpVG+5e74VFSg4rgJ2xXjEiQ==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
       }
     },
     "@types/webpack": {
-      "version": "4.41.17",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.17.tgz",
-      "integrity": "sha512-6FfeCidTSHozwKI67gIVQQ5Mp0g4X96c2IXxX75hYEQJwST/i6NyZexP//zzMOBb+wG9jJ7oO8fk9yObP2HWAw==",
+      "version": "4.41.21",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
+      "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -534,6 +562,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
       "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
+      "dev": true,
       "requires": {
         "gl-buffer": "^2.1.1",
         "gl-vao": "^1.2.0",
@@ -543,7 +572,8 @@
     "abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha1-32Acjo0roQ1KdtYl4japo5wnI78="
+      "integrity": "sha1-32Acjo0roQ1KdtYl4japo5wnI78=",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -556,24 +586,28 @@
       }
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "dev": true
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha1-SCIQFAWCo2uDw+NC4c/ryqkkCUg="
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4="
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
     },
     "add-line-numbers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
       "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
+      "dev": true,
       "requires": {
         "pad-left": "^1.0.2"
       }
@@ -582,6 +616,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
       "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
+      "dev": true,
       "requires": {
         "robust-orientation": "^1.1.3"
       }
@@ -610,25 +645,17 @@
       "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
     "almost-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
-      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
+      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0=",
+      "dev": true
     },
     "alpha-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
       "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
+      "dev": true,
       "requires": {
         "circumradius": "^1.0.0",
         "delaunay-triangulate": "^1.1.6"
@@ -638,16 +665,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
       "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
+      "dev": true,
       "requires": {
         "alpha-complex": "^1.0.0",
         "simplicial-complex-boundary": "^1.0.0"
       }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "optional": true
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -671,6 +693,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -702,6 +725,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -715,7 +739,8 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
@@ -726,7 +751,8 @@
     "array-bounds": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
-      "integrity": "sha1-2hE1a04Y4HWk8MhuHxeaZ7fX6jE="
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ==",
+      "dev": true
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -737,7 +763,8 @@
     "array-normalize": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
-      "integrity": "sha1-11zsVzgzWK84799qeAcao2rkF0w=",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+      "dev": true,
       "requires": {
         "array-bounds": "^1.0.0"
       }
@@ -745,12 +772,14 @@
     "array-range": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
-      "integrity": "sha1-9W5GWRhDYRxqVvd+8C7afFAIm/w="
+      "integrity": "sha1-9W5GWRhDYRxqVvd+8C7afFAIm/w=",
+      "dev": true
     },
     "array-rearrange": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
-      "integrity": "sha1-+hoqz40C6I3QyWAqoOBqeRWLIoM="
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==",
+      "dev": true
     },
     "array-union": {
       "version": "1.0.2",
@@ -847,17 +876,20 @@
     "atob-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
-      "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
+      "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "barycentric": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
       "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
+      "dev": true,
       "requires": {
         "robust-linear-solve": "^1.0.0"
       }
@@ -939,6 +971,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
       "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.2",
         "bn.js": "^4.11.6",
@@ -961,7 +994,8 @@
     "binary-search-bounds": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-      "integrity": "sha1-7qDkCB2pO6qFHH2FGn5jbD1RMH8="
+      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg==",
+      "dev": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -976,12 +1010,14 @@
     "bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4=",
+      "dev": true
     },
     "bitmap-sdf": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
-      "integrity": "sha1-yZkT5XKTV6b9NQ3jQVgYDAE4gLI=",
+      "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
+      "dev": true,
       "requires": {
         "clamp": "^1.0.1"
       }
@@ -990,6 +1026,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -998,12 +1035,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1017,7 +1056,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+              "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+              "dev": true
             }
           }
         },
@@ -1025,6 +1065,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           },
@@ -1032,7 +1073,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+              "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+              "dev": true
             }
           }
         }
@@ -1047,7 +1089,8 @@
     "bn.js": {
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -1093,6 +1136,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.1.tgz",
       "integrity": "sha1-6QWo0UGc9Hyza+Pb9SXbXiTeAEI=",
+      "dev": true,
       "requires": {
         "tape": "^4.0.0"
       }
@@ -1100,7 +1144,8 @@
     "box-intersect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
-      "integrity": "sha1-RpOtY+goho0GVLEU4JNk1igfP70=",
+      "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.2",
         "typedarray-pool": "^1.1.0"
@@ -1110,6 +1155,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1234,7 +1280,8 @@
     "buble": {
       "version": "0.19.8",
       "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
-      "integrity": "sha1-1kLwCBr6tm3M2JfXtjYNlAMLnT0=",
+      "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
+      "dev": true,
       "requires": {
         "acorn": "^6.1.1",
         "acorn-dynamic-import": "^4.0.0",
@@ -1249,14 +1296,16 @@
         "acorn": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ="
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "dev": true
         }
       }
     },
     "bubleify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.1.tgz",
-      "integrity": "sha1-wR+jP6WdW5t0fU5Ib0OIkIQlfzc=",
+      "integrity": "sha512-vp3NHmaQVoKaKWvi15FTMinPNjfp+47+/kFJ9ifezdMF/CBLArCxDVUh+FQE3qRxCRj1qyjJqilTBHHqlM8MaQ==",
+      "dev": true,
       "requires": {
         "buble": "^0.19.3"
       }
@@ -1283,7 +1332,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -1377,14 +1427,16 @@
       }
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "canvas-fit": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
+      "dev": true,
       "requires": {
         "element-size": "^1.1.1"
       }
@@ -1393,6 +1445,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
       "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^2.0.3",
         "robust-in-sphere": "^1.1.3",
@@ -1402,21 +1455,14 @@
     "cell-orientation": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cell-orientation/-/cell-orientation-1.0.1.tgz",
-      "integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
+      "integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1469,6 +1515,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
       "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
+      "dev": true,
       "requires": {
         "dup": "^1.0.0",
         "robust-linear-solve": "^1.0.0"
@@ -1478,6 +1525,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
       "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
+      "dev": true,
       "requires": {
         "circumcenter": "^1.0.0"
       }
@@ -1485,7 +1533,8 @@
     "clamp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ=",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -1523,6 +1572,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
       "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+      "dev": true,
       "requires": {
         "big-rat": "^1.0.3",
         "box-intersect": "^1.0.1",
@@ -1534,13 +1584,14 @@
       }
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       }
     },
     "collection-visit": {
@@ -1556,7 +1607,8 @@
     "color-alpha": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
-      "integrity": "sha1-wUHckm6V/D22R9DhTlvDZRwp4EA=",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
+      "dev": true,
       "requires": {
         "color-parse": "^1.3.8"
       }
@@ -1565,6 +1617,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       },
@@ -1572,14 +1625,16 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         }
       }
     },
     "color-id": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
-      "integrity": "sha1-XpFZuZpzrJj3SCDLmKFf3j1+A0w=",
+      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+      "dev": true,
       "requires": {
         "clamp": "^1.0.1"
       }
@@ -1587,12 +1642,14 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "color-normalize": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
-      "integrity": "sha1-7mEK+ayxXa9z53qUWoR7GOQHcto=",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
+      "dev": true,
       "requires": {
         "clamp": "^1.0.1",
         "color-rgba": "^2.1.1",
@@ -1602,7 +1659,8 @@
     "color-parse": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
-      "integrity": "sha1-6vVM04XLNMBoHxjCGKyjhHgIL6M=",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "defined": "^1.0.0",
@@ -1612,7 +1670,8 @@
     "color-rgba": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
-      "integrity": "sha1-RjO4OBfHQGyQs9e/TRrPpI3eXIM=",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
+      "dev": true,
       "requires": {
         "clamp": "^1.0.1",
         "color-parse": "^1.3.8",
@@ -1622,7 +1681,8 @@
     "color-space": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
-      "integrity": "sha1-YReBvKQc2FgqFGb9niin09iXcqI=",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "dev": true,
       "requires": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
@@ -1631,7 +1691,8 @@
     "colormap": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
-      "integrity": "sha1-nyq2Q1kcByjTIzLVSAskh6Tg8kk=",
+      "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
+      "dev": true,
       "requires": {
         "lerp": "^1.0.3"
       }
@@ -1645,7 +1706,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -1657,6 +1719,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
       "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
+      "dev": true,
       "requires": {
         "robust-orientation": "^1.0.2",
         "robust-product": "^1.0.0",
@@ -1668,12 +1731,14 @@
     "compare-cell": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/compare-cell/-/compare-cell-1.0.0.tgz",
-      "integrity": "sha1-qetwj24OQa73qlZrEw8ZaNyeGqo="
+      "integrity": "sha1-qetwj24OQa73qlZrEw8ZaNyeGqo=",
+      "dev": true
     },
     "compare-oriented-cell": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
       "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
+      "dev": true,
       "requires": {
         "cell-orientation": "^1.0.1",
         "compare-cell": "^1.0.0"
@@ -1720,7 +1785,8 @@
     "compute-dims": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
-      "integrity": "sha1-bVtxKSm2xTGvO01YDtWtrLvXfgw=",
+      "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
+      "dev": true,
       "requires": {
         "utils-copy": "^1.0.0",
         "validate.io-array": "^1.0.6",
@@ -1732,12 +1798,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -1748,12 +1816,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1767,12 +1837,14 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -1794,12 +1866,14 @@
     "const-max-uint32": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
-      "integrity": "sha1-8Am7YjDmeO2HTdLWqc2ePL+rtnY="
+      "integrity": "sha1-8Am7YjDmeO2HTdLWqc2ePL+rtnY=",
+      "dev": true
     },
     "const-pinf-float64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
-      "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY="
+      "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -1834,6 +1908,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
       "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
+      "dev": true,
       "requires": {
         "affine-hull": "^1.0.0",
         "incremental-convex-hull": "^1.0.1",
@@ -1886,12 +1961,14 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
-      "integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY="
+      "integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY=",
+      "dev": true
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -1973,7 +2050,8 @@
     "css-font": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
-      "integrity": "sha1-5zy9wR/YfI5skorXCYqXccjCtuM=",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "dev": true,
       "requires": {
         "css-font-size-keywords": "^1.0.0",
         "css-font-stretch-keywords": "^1.0.1",
@@ -1989,32 +2067,37 @@
     "css-font-size-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss="
+      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
+      "dev": true
     },
     "css-font-stretch-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA="
+      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
+      "dev": true
     },
     "css-font-style-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ="
+      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
+      "dev": true
     },
     "css-font-weight-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc="
+      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
+      "dev": true
     },
     "css-global-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk="
+      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
+      "dev": true
     },
     "css-loader": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.3.tgz",
-      "integrity": "sha1-lawWRo4a3NlchEcp4LsWdjnrC88=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
@@ -2022,78 +2105,47 @@
         "icss-utils": "^4.1.1",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.27",
+        "postcss": "^7.0.32",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
         "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.0.3",
-        "schema-utils": "^2.6.6",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^2.7.0",
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-          "dev": true
-        }
       }
     },
     "css-system-font-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0="
+      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
+      "dev": true
     },
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
+      "dev": true
     },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cubic-hermite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
-      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
-    },
-    "cwise": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
-      "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
-      "requires": {
-        "cwise-compiler": "^1.1.1",
-        "cwise-parser": "^1.0.0",
-        "static-module": "^1.0.0",
-        "uglify-js": "^2.6.0"
-      }
+      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU=",
+      "dev": true
     },
     "cwise-compiler": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
       "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "dev": true,
       "requires": {
         "uniq": "^1.0.0"
-      }
-    },
-    "cwise-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
-      "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
-      "requires": {
-        "esprima": "^1.0.3",
-        "uniq": "^1.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-          "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
-        }
       }
     },
     "cyclist": {
@@ -2105,7 +2157,8 @@
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -2114,32 +2167,38 @@
     "d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
+      "dev": true
     },
     "d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha1-Y1zk1e6nWfb2BYY9vPww7cc39x8="
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "dev": true
     },
     "d3-collection": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha1-NJvSqpl32wcQkcExRNXk8WtbMQ4="
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+      "dev": true
     },
     "d3-color": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha1-xSACv4hGraRCTVXZeYL+8m6zvIo="
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "dev": true
     },
     "d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha1-ANN7zuTdjNl3Kd2JOgrCnKq6XVg="
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "dev": true
     },
     "d3-force": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
-      "integrity": "sha1-/Sml0f8YHJ5/BmnkvXK9sOkU7As=",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "dev": true,
       "requires": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -2150,12 +2209,14 @@
     "d3-hierarchy": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha1-L2vuJMqupD+Nw3VF+gFihVlkeoM="
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==",
+      "dev": true
     },
     "d3-interpolate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha1-Um554tgNqjg/ngwcHH3MDwWD6Yc=",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dev": true,
       "requires": {
         "d3-color": "1"
       }
@@ -2163,17 +2224,20 @@
     "d3-path": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha1-SMBQux/owmJJOoyvVSTj6VkXAc8="
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true
     },
     "d3-quadtree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha1-youE33u1N2P+PC8kvUNRN/TlMTU="
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
+      "dev": true
     },
     "d3-shape": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha1-32OAG+B7yYa8VPY3ibT+UCmStdc=",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
       "requires": {
         "d3-path": "1"
       }
@@ -2181,7 +2245,8 @@
     "d3-timer": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha1-3+dripF0iDGxO22ceT/71QjdneU="
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -2195,7 +2260,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2207,6 +2273,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
+      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -2219,7 +2286,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -2235,6 +2303,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -2289,7 +2358,8 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "del": {
       "version": "4.1.1",
@@ -2332,6 +2402,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
       "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
+      "dev": true,
       "requires": {
         "incremental-convex-hull": "^1.0.1",
         "uniq": "^1.0.1"
@@ -2386,7 +2457,8 @@
     "detect-kerning": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
-      "integrity": "sha1-Ts1UjkpaP8iA/ipQYJMS0AD6n8I="
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==",
+      "dev": true
     },
     "detect-node": {
       "version": "2.0.4",
@@ -2491,7 +2563,8 @@
     "dotignore": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha1-+ULyIA0ow6dvvdbw7p8yV8ii6QU=",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -2499,12 +2572,14 @@
     "double-bits": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
-      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY=",
+      "dev": true
     },
     "draw-svg-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
+      "dev": true,
       "requires": {
         "abs-svg-path": "~0.1.1",
         "normalize-svg-path": "~0.1.0"
@@ -2550,38 +2625,20 @@
     "dtype": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
-      "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ="
+      "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ=",
+      "dev": true
     },
     "dup": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "requires": {
-        "readable-stream": "~1.1.9"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
+      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk=",
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -2592,12 +2649,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2611,12 +2670,14 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -2626,12 +2687,14 @@
     "earcut": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha1-QbC8NfY+D+gNp83f8oUR5+LoDRE="
+      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==",
+      "dev": true
     },
     "edges-to-adjacency-list": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
       "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
+      "dev": true,
       "requires": {
         "uniq": "^1.0.0"
       }
@@ -2645,12 +2708,14 @@
     "element-size": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
-      "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404="
+      "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404=",
+      "dev": true
     },
     "elementary-circuits-directed-graph": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.2.0.tgz",
-      "integrity": "sha1-xlB/QlZlB8ZGtbsUS4kvvOFlY3E=",
+      "integrity": "sha512-eOQofnrNqebPtC29PvyNMGUBdMrIw5i8nOoC/2VOlSF84tf5+ZXnRkIk7TgdT22jFXK68CC7aA881KRmNYf/Pg==",
+      "dev": true,
       "requires": {
         "strongly-connected-components": "^1.0.1"
       }
@@ -2692,6 +2757,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -2710,7 +2776,8 @@
     "entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -2725,6 +2792,7 @@
       "version": "1.17.5",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
       "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -2743,6 +2811,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -2752,7 +2821,8 @@
     "es5-ext": {
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -2763,6 +2833,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -2772,12 +2843,14 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -2786,7 +2859,8 @@
     "es6-weak-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha1-ttofFswswNm+Q+a9v8Xn383zHVM=",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -2803,12 +2877,14 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha1-ugHQyCeLXpWppFNQFCAmZZAnpFc=",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -2830,7 +2906,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -2844,12 +2921,14 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0="
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -2866,7 +2945,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "eventsource": {
       "version": "1.0.7",
@@ -3001,7 +3081,8 @@
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha1-ia56BxWPedNVF4gpBDJAd+Q3kkQ=",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
       "requires": {
         "type": "^2.0.0"
       },
@@ -3009,7 +3090,8 @@
         "type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha1-Xxb/bvLrRPJgSU2uJxAzspwJqcM="
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
         }
       }
     },
@@ -3108,12 +3190,14 @@
     "extract-frustum-planes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/extract-frustum-planes/-/extract-frustum-planes-1.0.0.tgz",
-      "integrity": "sha1-l9VwP/BWTIw8aDjKxF+ee8UsnvU="
+      "integrity": "sha1-l9VwP/BWTIw8aDjKxF+ee8UsnvU=",
+      "dev": true
     },
     "falafel": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
-      "integrity": "sha1-tdhsBgwkEqQxZiQ8sbzkTRq9KBk=",
+      "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
+      "dev": true,
       "requires": {
         "acorn": "^7.1.1",
         "foreach": "^2.0.5",
@@ -3124,7 +3208,8 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
         }
       }
     },
@@ -3137,7 +3222,8 @@
     "fast-isnumeric": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
-      "integrity": "sha1-4WV4b/RxxDnprOK4yOZszrR+LqQ=",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
+      "dev": true,
       "requires": {
         "is-string-blank": "^1.0.1"
       }
@@ -3151,7 +3237,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -3188,6 +3275,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.4.tgz",
       "integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^1.0.0",
         "cubic-hermite": "^1.0.0"
@@ -3196,7 +3284,8 @@
         "binary-search-bounds": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k=",
+          "dev": true
         }
       }
     },
@@ -3238,7 +3327,7 @@
     "findup-sync": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-      "integrity": "sha1-F7EI+e5RLft6XH88iyfqnhqcCNE=",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "dev": true,
       "requires": {
         "detect-file": "^1.0.0",
@@ -3250,7 +3339,7 @@
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -3322,13 +3411,13 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -3361,7 +3450,8 @@
     "flatten-vertex-data": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
-      "integrity": "sha1-iJ/WC+pQYAbKM5Ve4RBRdftiAhk=",
+      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+      "dev": true,
       "requires": {
         "dtype": "^2.0.0"
       }
@@ -3369,7 +3459,8 @@
     "flip-pixels": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flip-pixels/-/flip-pixels-1.0.2.tgz",
-      "integrity": "sha1-qte32fxlky1fJ+Lk2sS0lBQIReQ="
+      "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA==",
+      "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -3448,7 +3539,8 @@
     "font-atlas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
-      "integrity": "sha1-qi1tz2VqbIcdZqu9PfvqL3cXg0g=",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+      "dev": true,
       "requires": {
         "css-font": "^1.0.0"
       }
@@ -3456,7 +3548,8 @@
     "font-measure": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
-      "integrity": "sha1-QdvaxdIw2/TbCIZfVNoopHXoMCY=",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+      "dev": true,
       "requires": {
         "css-font": "^1.2.0"
       }
@@ -3464,7 +3557,8 @@
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -3478,7 +3572,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3505,6 +3600,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -3513,12 +3609,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3532,12 +3630,14 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3556,7 +3656,7 @@
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
@@ -3579,7 +3679,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.1.3",
@@ -3591,22 +3692,26 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gamma": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
-      "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
+      "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA=",
+      "dev": true
     },
     "geojson-vt": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha1-+K22FNLB0/bufEJlytS7861gyLc="
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3617,7 +3722,8 @@
     "get-canvas-context": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
-      "integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM="
+      "integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM=",
+      "dev": true
     },
     "get-stdin": {
       "version": "0.1.0",
@@ -3643,7 +3749,8 @@
     "gl-axes3d": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.5.3.tgz",
-      "integrity": "sha1-R+PdbCE1alk0mRDsAa9Y4o6mn+k=",
+      "integrity": "sha512-KRYbguKQcDQ6PcB9g1pgqB8Ly4TY1DQODpPKiDTasyWJ8PxQk0t2Q7XoQQijNqvsguITCpVVCzNb5GVtIWiVlQ==",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.2",
         "dup": "^1.0.0",
@@ -3664,6 +3771,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
       "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
+      "dev": true,
       "requires": {
         "ndarray": "^1.0.15",
         "ndarray-ops": "^1.1.0",
@@ -3673,7 +3781,8 @@
     "gl-cone3d": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.5.2.tgz",
-      "integrity": "sha1-Zq9cM7fVF0A036NlSojplZmNkrw=",
+      "integrity": "sha512-1JNeHH4sUtUmDA4ZK7Om8/kShwb8IZVAsnxaaB7IPRJsNGciLj1sTpODrJGeMl41RNkex5kXD2SQFrzyEAR2Rw==",
+      "dev": true,
       "requires": {
         "colormap": "^2.3.1",
         "gl-buffer": "^2.1.2",
@@ -3692,12 +3801,14 @@
     "gl-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
-      "integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM="
+      "integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM=",
+      "dev": true
     },
     "gl-contour2d": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.7.tgz",
-      "integrity": "sha1-yjMM+ESWc6nKCz9nJsg/jTXHpQw=",
+      "integrity": "sha512-GdebvJ9DtT3pJDpoE+eU2q+Wo9S3MijPpPz5arZbhK85w2bARmpFpVfPaDlZqWkB644W3BlH8TVyvAo1KE4Bhw==",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "cdt2d": "^1.0.0",
@@ -3713,7 +3824,8 @@
     "gl-error3d": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.16.tgz",
-      "integrity": "sha1-iKlJUvUwPZz1y4aAZ4mjYHd8VEY=",
+      "integrity": "sha512-TGJewnKSp7ZnqGgG3XCF9ldrDbxZrO+OWlx6oIet4OdOM//n8xJ5isArnIV/sdPJnFbhfoLxWrW9f5fxHFRQ1A==",
+      "dev": true,
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
@@ -3726,6 +3838,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
       "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
+      "dev": true,
       "requires": {
         "gl-texture2d": "^2.0.0"
       }
@@ -3734,6 +3847,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
       "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
+      "dev": true,
       "requires": {
         "add-line-numbers": "^1.0.1",
         "gl-constants": "^1.0.0",
@@ -3744,7 +3858,8 @@
     "gl-heatmap2d": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.6.tgz",
-      "integrity": "sha1-0KLZ6PWXVTQiSzsr4v/mg/a36WE=",
+      "integrity": "sha512-+agzSv4R5vsaH+AGYVz5RVzBK10amqAa+Bwj205F13JjNSGS91M1L9Yb8zssCv2FIjpP+1Mp73cFBYrQFfS1Jg==",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",
@@ -3758,6 +3873,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.1.tgz",
       "integrity": "sha512-eeb0+RI2ZBRqMYJK85SgsRiJK7c4aiOjcnirxv0830A3jmOc99snY3AbPcV8KvKmW0Yaf3KA4e+qNCbHiTOTnA==",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",
@@ -3769,40 +3885,29 @@
         "ndarray": "^1.0.18"
       }
     },
-    "gl-mat2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gl-mat2/-/gl-mat2-1.0.1.tgz",
-      "integrity": "sha1-FCUFcwpcL+Hp8l2ezj0NbMJxCjA="
-    },
     "gl-mat3": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
-      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI=",
+      "dev": true
     },
     "gl-mat4": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
-      "integrity": "sha1-SdinY2twqgCBkhZjX0o/0/RmmyY="
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA==",
+      "dev": true
     },
     "gl-matrix": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
-      "integrity": "sha1-Iy7vYLHIswooy751ssr2xI/WNYs="
-    },
-    "gl-matrix-invert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
-      "integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
-      "requires": {
-        "gl-mat2": "^1.0.0",
-        "gl-mat3": "^1.0.0",
-        "gl-mat4": "^1.0.0"
-      }
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==",
+      "dev": true
     },
     "gl-mesh3d": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.3.1.tgz",
-      "integrity": "sha1-CHqTxUMd+SNXDKUc/Gkbqw0hprg=",
+      "integrity": "sha512-pXECamyGgu4/9HeAQSE5OEUuLBGS1aq9V4BCsTcxsND4fNLaajEkYKUz/WY2QSYElqKdsMBVsldGiKRKwlybqA==",
+      "dev": true,
       "requires": {
         "barycentric": "^1.0.1",
         "colormap": "^2.3.1",
@@ -3822,13 +3927,14 @@
       }
     },
     "gl-plot2d": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.4.tgz",
-      "integrity": "sha1-Lb5Ad2BRQ2uvCUf4KO4sjDA9K9s=",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.5.tgz",
+      "integrity": "sha512-6GmCN10SWtV+qHFQ1gjdnVubeHFVsm6P4zmo0HrPIl9TcdePCUHDlBKWAuE6XtFhiMKMj7R8rApOX8O8uXUYog==",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",
-        "gl-select-static": "^2.0.6",
+        "gl-select-static": "^2.0.7",
         "gl-shader": "^4.2.1",
         "glsl-inverse": "^1.0.0",
         "glslify": "^7.0.0",
@@ -3836,16 +3942,17 @@
       }
     },
     "gl-plot3d": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.5.tgz",
-      "integrity": "sha1-li6Zw+VYYuCtd+mRFFZurbKL8iQ=",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.6.tgz",
+      "integrity": "sha512-CkrNvDKu0p74Di2g2Oc9kU+s1Oe+wi4cIfHzXABp8DvfoRl0/bayqJ9q8EcRAqMeQQxQZYGvJkk4hlBwI758Jw==",
+      "dev": true,
       "requires": {
         "3d-view": "^2.0.0",
         "a-big-triangle": "^1.0.3",
         "gl-axes3d": "^1.5.3",
         "gl-fbo": "^2.0.5",
         "gl-mat4": "^1.2.0",
-        "gl-select-static": "^2.0.6",
+        "gl-select-static": "^2.0.7",
         "gl-shader": "^4.2.1",
         "gl-spikes3d": "^1.0.10",
         "glslify": "^7.0.0",
@@ -3854,14 +3961,15 @@
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
-        "ndarray": "^1.0.18",
+        "ndarray": "^1.0.19",
         "right-now": "^1.0.0"
       }
     },
     "gl-pointcloud2d": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.3.tgz",
-      "integrity": "sha1-834hXyHMsuF/BgRmTpn8PWpOYR0=",
+      "integrity": "sha512-OS2e1irvJXVRpg/GziXj10xrFJm9kkRfFoB6BLUvkjCQV7ZRNNcs2CD+YSK1r0gvMwTg2T3lfLM3UPwNtz+4Xw==",
+      "dev": true,
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
@@ -3873,6 +3981,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
       "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
+      "dev": true,
       "requires": {
         "gl-mat3": "^1.0.0",
         "gl-vec3": "^1.0.3",
@@ -3882,7 +3991,8 @@
     "gl-scatter3d": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.2.3.tgz",
-      "integrity": "sha1-g9Y3AOwv5OlbPRzWE+ht6aa19gM=",
+      "integrity": "sha512-nXqPlT1w5Qt51dTksj+DUqrZqwWAEWg0PocsKcoDnVNv0X8sGA+LBZ0Y+zrA+KNXUL0PPCX9WR9cF2uJAZl1Sw==",
+      "dev": true,
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-mat4": "^1.2.0",
@@ -3898,7 +4008,8 @@
     "gl-select-box": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.4.tgz",
-      "integrity": "sha1-R8EcqiuE+B6Lv94IxuOe7rtT09g=",
+      "integrity": "sha512-mKsCnglraSKyBbQiGq0Ila0WF+m6Tr+EWT2yfaMn/Sh9aMHq5Wt0F/l6Cf/Ed3CdERq5jHWAY5yxLviZteYu2w==",
+      "dev": true,
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
@@ -3906,12 +4017,12 @@
       }
     },
     "gl-select-static": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.6.tgz",
-      "integrity": "sha1-QxlKNIYTppPUCX5auc6waFAD8DY=",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.7.tgz",
+      "integrity": "sha512-OvpYprd+ngl3liEatBTdXhSyNBjwvjMSvV2rN0KHpTU+BTi4viEETXNZXFgGXY37qARs0L28ybk3UQEW6C5Nnw==",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.2",
-        "cwise": "^1.0.10",
         "gl-fbo": "^2.0.5",
         "ndarray": "^1.0.18",
         "typedarray-pool": "^1.1.0"
@@ -3921,6 +4032,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
       "integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
+      "dev": true,
       "requires": {
         "gl-format-compiler-error": "^1.0.2",
         "weakmap-shim": "^1.1.0"
@@ -3929,12 +4041,14 @@
     "gl-spikes2d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.2.tgz",
-      "integrity": "sha1-7428/2x0Ud7Ct1HXo8WT0JrVRX8="
+      "integrity": "sha512-QVeOZsi9nQuJJl7NB3132CCv5KA10BWxAY2QgJNsKqbLsG53B/TrGJpjIAohnJftdZ4fT6b3ZojWgeaXk8bOOA==",
+      "dev": true
     },
     "gl-spikes3d": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.10.tgz",
-      "integrity": "sha1-47K2d6b1F1DyPAZER69PCT2nkwU=",
+      "integrity": "sha512-lT3xroowOFxMvlhT5Mof76B2TE02l5zt/NIWljhczV2FFHgIVhA4jMrd5dIv1so1RXMBDJIKu0uJI3QKliDVLg==",
+      "dev": true,
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
@@ -3946,6 +4060,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
       "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
+      "dev": true,
       "requires": {
         "uniq": "^1.0.0"
       }
@@ -3953,7 +4068,8 @@
     "gl-streamtube3d": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.4.1.tgz",
-      "integrity": "sha1-vStyXgCqlpic40sG6/Zqdvk+Na4=",
+      "integrity": "sha512-rH02v00kgwgdpkXVo7KsSoPp38bIAYR9TE1iONjcQ4cQAlDhrGRauqT/P5sUaOIzs17A2DxWGcXM+EpNQs9pUA==",
+      "dev": true,
       "requires": {
         "gl-cone3d": "^1.5.2",
         "gl-vec3": "^1.1.3",
@@ -3967,7 +4083,8 @@
     "gl-surface3d": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.5.2.tgz",
-      "integrity": "sha1-ooO5jTRz/KToVS8PasQKbw3IiwA=",
+      "integrity": "sha512-rWSQwEQDkB0T5CDEDFJwJc4VgwwJaAyFRSJ92NJlrTSwDlsEsWdzG9+APx6FWJMwkOpIoZGWqv+csswK2kMMLQ==",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "bit-twiddle": "^1.0.2",
@@ -3993,7 +4110,8 @@
     "gl-text": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.8.tgz",
-      "integrity": "sha1-Z6Gb7HKRWsxCIwCq2PcnoJ+YtVA=",
+      "integrity": "sha512-whnq9DEFYbW92C4ONwk2eT0YkzmVPHoADnEtuzMOmit87XhgAhBrNs3lK9EgGjU/MoWYvlF6RkI8Kl7Yuo1hUw==",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -4018,6 +4136,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
       "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
+      "dev": true,
       "requires": {
         "ndarray": "^1.0.15",
         "ndarray-ops": "^1.2.2",
@@ -4028,6 +4147,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
       "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "dev": true,
       "requires": {
         "is-browser": "^2.0.1",
         "is-firefox": "^1.0.3",
@@ -4041,22 +4161,26 @@
     "gl-vao": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/gl-vao/-/gl-vao-1.3.0.tgz",
-      "integrity": "sha1-6ekqqVWIyrnVwvBLaTRAw99pGSM="
+      "integrity": "sha1-6ekqqVWIyrnVwvBLaTRAw99pGSM=",
+      "dev": true
     },
     "gl-vec3": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gl-vec3/-/gl-vec3-1.1.3.tgz",
-      "integrity": "sha1-pHxi+Rh3SgbL7RtlvNAojsuwOCY="
+      "integrity": "sha512-jduKUqT0SGH02l8Yl+mV1yVsDfYgQAJyXGxkJQGyxPLHRiW25DwVIRPt6uvhrEMHftJfqhqKthRcyZqNEl9Xdw==",
+      "dev": true
     },
     "gl-vec4": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gl-vec4/-/gl-vec4-1.0.1.tgz",
-      "integrity": "sha1-l9loeCgbFLUyy84QF4Xf0cs0CWQ="
+      "integrity": "sha1-l9loeCgbFLUyy84QF4Xf0cs0CWQ=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4079,7 +4203,7 @@
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "dev": true,
       "requires": {
         "global-prefix": "^3.0.0"
@@ -4088,7 +4212,7 @@
         "global-prefix": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-          "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
           "dev": true,
           "requires": {
             "ini": "^1.3.5",
@@ -4099,7 +4223,7 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -4142,6 +4266,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
+      "dev": true,
       "requires": {
         "glsl-token-inject-block": "^1.0.0",
         "glsl-token-string": "^1.0.1",
@@ -4151,17 +4276,20 @@
     "glsl-inverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-inverse/-/glsl-inverse-1.0.0.tgz",
-      "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
+      "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY=",
+      "dev": true
     },
     "glsl-out-of-range": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.4.tgz",
-      "integrity": "sha1-PXPQg7yezHPv1F38cGPCnpLJyHM="
+      "integrity": "sha512-fCcDu2LCQ39VBvfe1FbhuazXEf0CqMZI9OYXrYlL6uUARG48CTAbL04+tZBtVM0zo1Ljx4OLu2AxNquq++lxWQ==",
+      "dev": true
     },
     "glsl-resolve": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
+      "dev": true,
       "requires": {
         "resolve": "^0.6.1",
         "xtend": "^2.1.2"
@@ -4170,12 +4298,14 @@
         "resolve": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
-          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+          "dev": true
         },
         "xtend": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
-          "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
+          "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=",
+          "dev": true
         }
       }
     },
@@ -4183,6 +4313,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
       "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
+      "dev": true,
       "requires": {
         "atob-lite": "^1.0.0",
         "glsl-tokenizer": "^2.0.2"
@@ -4191,12 +4322,14 @@
     "glsl-specular-beckmann": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
-      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
+      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE=",
+      "dev": true
     },
     "glsl-specular-cook-torrance": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
+      "dev": true,
       "requires": {
         "glsl-specular-beckmann": "^1.1.1"
       }
@@ -4204,12 +4337,14 @@
     "glsl-token-assignments": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
-      "integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8="
+      "integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8=",
+      "dev": true
     },
     "glsl-token-defines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
+      "dev": true,
       "requires": {
         "glsl-tokenizer": "^2.0.0"
       }
@@ -4217,12 +4352,14 @@
     "glsl-token-depth": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
-      "integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ="
+      "integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ=",
+      "dev": true
     },
     "glsl-token-descope": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
+      "dev": true,
       "requires": {
         "glsl-token-assignments": "^2.0.0",
         "glsl-token-depth": "^1.1.0",
@@ -4233,32 +4370,38 @@
     "glsl-token-inject-block": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
-      "integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ="
+      "integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ=",
+      "dev": true
     },
     "glsl-token-properties": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
-      "integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4="
+      "integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4=",
+      "dev": true
     },
     "glsl-token-scope": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
-      "integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E="
+      "integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E=",
+      "dev": true
     },
     "glsl-token-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
-      "integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw="
+      "integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw=",
+      "dev": true
     },
     "glsl-token-whitespace-trim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
-      "integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA="
+      "integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA=",
+      "dev": true
     },
     "glsl-tokenizer": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
-      "integrity": "sha1-HC54wWWJkzwnS6J40KY7Nwxf7ho=",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dev": true,
       "requires": {
         "through2": "^0.6.3"
       }
@@ -4266,7 +4409,8 @@
     "glslify": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-      "integrity": "sha1-ENXblUHuB8ZUjqVcZ57dogMHZT0=",
+      "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
+      "dev": true,
       "requires": {
         "bl": "^1.0.0",
         "concat-stream": "^1.5.2",
@@ -4288,12 +4432,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4307,12 +4453,14 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4320,7 +4468,8 @@
         "through2": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -4331,7 +4480,8 @@
     "glslify-bundle": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
-      "integrity": "sha1-MNLd8ua5Nb9E0SmTIeO3KXgsQJo=",
+      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
+      "dev": true,
       "requires": {
         "glsl-inject-defines": "^1.0.1",
         "glsl-token-defines": "^1.0.0",
@@ -4348,7 +4498,8 @@
     "glslify-deps": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.1.tgz",
-      "integrity": "sha1-36aWIyJFSpHsxN4ltecQQVsMia0=",
+      "integrity": "sha512-Ogm179MCazwIRyEqs3g3EOY4Y3XIAa0yl8J5RE9rJC6QH1w8weVOp2RZu0mvnYy/2xIas1w166YR2eZdDkWQxg==",
+      "dev": true,
       "requires": {
         "@choojs/findup": "^0.2.0",
         "events": "^1.0.2",
@@ -4363,12 +4514,14 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
+      "dev": true
     },
     "grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
-      "integrity": "sha1-l/giHt7BAmyDd7hkRqfHHnlSLqc="
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
+      "dev": true
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -4379,7 +4532,7 @@
     "handlebars": {
       "version": "4.7.6",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha1-1MBcG6+Q6ZRfd6pop6IZqkp9904=",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -4387,30 +4540,13 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "uglify-js": {
-          "version": "3.9.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-          "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.20.3"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
       }
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4418,12 +4554,14 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-hover": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
+      "dev": true,
       "requires": {
         "is-browser": "^2.0.1"
       }
@@ -4431,7 +4569,8 @@
     "has-passive-events": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
-      "integrity": "sha1-dfw9xtraGCxY8k673AGCdtHqNRU=",
+      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
+      "dev": true,
       "requires": {
         "is-browser": "^2.0.1"
       }
@@ -4439,7 +4578,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg="
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -4543,9 +4683,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
-      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
+      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==",
       "dev": true
     },
     "hmac-drbg": {
@@ -4562,7 +4702,7 @@
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -4627,7 +4767,8 @@
     "hsluv": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
-      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
+      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw=",
+      "dev": true
     },
     "html-entities": {
       "version": "1.3.1",
@@ -4884,7 +5025,7 @@
     "icss-utils": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-      "integrity": "sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
@@ -4893,7 +5034,8 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q="
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -4937,7 +5079,8 @@
     "image-palette": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
-      "integrity": "sha1-2XZSWh33WWTKEl0tuidB6SkFVH8=",
+      "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
+      "dev": true,
       "requires": {
         "color-id": "^1.1.0",
         "pxls": "^2.0.0",
@@ -4964,6 +5107,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
       "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
+      "dev": true,
       "requires": {
         "robust-orientation": "^1.1.2",
         "simplicial-complex": "^1.0.0"
@@ -4985,6 +5129,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4993,12 +5138,13 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "internal-ip": {
@@ -5021,6 +5167,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^1.0.0"
       },
@@ -5028,25 +5175,22 @@
         "binary-search-bounds": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k=",
+          "dev": true
         }
       }
-    },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
-      "dev": true
     },
     "invert-permutation": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-permutation/-/invert-permutation-1.0.0.tgz",
-      "integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM="
+      "integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM=",
+      "dev": true
     },
     "iota-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
-      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -5084,12 +5228,14 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM="
+      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
+      "dev": true
     },
     "is-base64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
-      "integrity": "sha1-pvIGEMbvSGOlHLoyvAIiVEuTJiI="
+      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg==",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -5104,22 +5250,26 @@
     "is-blob": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
-      "integrity": "sha1-42zYLJBlPx4bkw8RuvnGQhagU4U="
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true
     },
     "is-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
-      "integrity": "sha1-/AhNWaX87TB9ZwjFk1a61wBzcak="
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ==",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -5133,7 +5283,8 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4="
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -5169,17 +5320,20 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM="
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-firefox": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
-      "integrity": "sha1-KioVZ3g6QX9uFYMjEI84YbCRhWI="
+      "integrity": "sha1-KioVZ3g6QX9uFYMjEI84YbCRhWI=",
+      "dev": true
     },
     "is-float-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-float-array/-/is-float-array-1.0.0.tgz",
-      "integrity": "sha1-ltZ7HLrfR6seBb4giTOs04aXigk="
+      "integrity": "sha512-4ew1Sx6B6kEAl3T3NOM0yB94J3NZnBdNt4paw0e8nY73yHHTeTEhyQ3Lj7EQEnv5LD+GxNTaT4L46jcKjjpLiQ==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -5199,12 +5353,14 @@
     "is-iexplorer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
-      "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY="
+      "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY=",
+      "dev": true
     },
     "is-mobile": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.1.tgz",
-      "integrity": "sha1-EPIyABLEEMwoX+7LE0Br1Ybxsvg="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -5215,7 +5371,8 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -5244,7 +5401,8 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -5259,6 +5417,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -5272,17 +5431,20 @@
     "is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
-      "integrity": "sha1-hm3KBm1B0olOvf0tj+k+WG5YOgM="
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw==",
+      "dev": true
     },
     "is-svg-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
-      "integrity": "sha1-d6tZDBKz0gNI5cehPQBAyHeE3aA="
+      "integrity": "sha1-d6tZDBKz0gNI5cehPQBAyHeE3aA=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -5302,7 +5464,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -5335,7 +5498,8 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -5376,7 +5540,8 @@
     "kdbush": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha1-+EhHlNRwBMwthe06eTU9vgq8K/A="
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+      "dev": true
     },
     "killable": {
       "version": "1.0.1",
@@ -5388,47 +5553,38 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "is-buffer": "^1.1.5"
       }
     },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4="
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "lerp": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
-      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24="
+      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha1-47VGl+eL+RXHCjis14/QngBYsc8=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -5472,11 +5628,6 @@
       "integrity": "sha1-iiX7ddCSIw7NRFcnDYC1TigBEXE=",
       "dev": true
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
     "lower-case": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
@@ -5498,13 +5649,14 @@
     "lunr": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-      "integrity": "sha1-qLicMfMLWgRLl9LSji2hkba6IHI=",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
       "dev": true
     },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha1-P0l9b9NMZpxnmNy4IfLvMfVEUFE=",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -5533,15 +5685,6 @@
       "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
       "dev": true
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -5552,6 +5695,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+      "dev": true,
       "requires": {
         "once": "~1.3.0"
       },
@@ -5560,6 +5704,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5576,9 +5721,10 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.0.tgz",
-      "integrity": "sha512-SrJXcR9s5yEsPuW2kKKumA1KqYW9RrL8j7ZcIh6glRQ/x3lwNMfwz/UEJAJcVNgeX+fiwzuBoDIdeGB/vSkZLQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "dev": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -5609,18 +5755,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
       "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
+      "dev": true,
       "requires": {
         "convex-hull": "^1.0.3"
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha1-q/xk8UGxci1mNAIETkOSfx9QqNw=",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-11.0.0.tgz",
+      "integrity": "sha512-+CvOnmbSubmQFSA9dKz1BRiaSMV7rhexl3sngKqFyXSagoA3fBdJQ8oZWtRy2knXdpDXaBw44euz37DeJQ9asg==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       }
@@ -5628,13 +5776,14 @@
     "marked": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-      "integrity": "sha1-01eEJFoEhx5ZiKSR4ohnNi6UFpM=",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
       "dev": true
     },
     "mat4-decompose": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
       "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
+      "dev": true,
       "requires": {
         "gl-mat4": "^1.0.1",
         "gl-vec3": "^1.0.2"
@@ -5644,6 +5793,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
       "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
+      "dev": true,
       "requires": {
         "gl-mat4": "^1.0.1",
         "gl-vec3": "^1.0.2",
@@ -5656,6 +5806,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
       "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
+      "dev": true,
       "requires": {
         "gl-mat4": "^1.0.1"
       }
@@ -5663,12 +5814,14 @@
     "math-log2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
-      "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU="
+      "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU=",
+      "dev": true
     },
     "matrix-camera-controller": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
       "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^1.0.0",
         "gl-mat4": "^1.1.2",
@@ -5679,7 +5832,8 @@
         "binary-search-bounds": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k=",
+          "dev": true
         }
       }
     },
@@ -5697,24 +5851,14 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      }
     },
     "memory-fs": {
       "version": "0.5.0",
@@ -5779,7 +5923,7 @@
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
       "dev": true,
       "requires": {
         "braces": "^3.0.1",
@@ -5817,12 +5961,6 @@
         "mime-db": "1.44.0"
       }
     },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-      "dev": true
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5839,6 +5977,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5846,7 +5985,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
     },
     "mississippi": {
       "version": "3.0.0",
@@ -5948,6 +6088,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
       "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "dev": true,
       "requires": {
         "robust-orientation": "^1.1.3"
       }
@@ -5956,6 +6097,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
+      "dev": true,
       "requires": {
         "mouse-event": "^1.0.0"
       }
@@ -5963,17 +6105,20 @@
     "mouse-event": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
-      "integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI="
+      "integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI=",
+      "dev": true
     },
     "mouse-event-offset": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
-      "integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ="
+      "integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ=",
+      "dev": true
     },
     "mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
+      "dev": true,
       "requires": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -5983,7 +6128,8 @@
         "signum": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
-          "integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc="
+          "integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc=",
+          "dev": true
         }
       }
     },
@@ -6094,6 +6240,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
       "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
+      "dev": true,
       "requires": {
         "almost-equal": "^1.1.0"
       }
@@ -6101,7 +6248,8 @@
     "murmurhash-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=",
+      "dev": true
     },
     "nan": {
       "version": "2.14.1",
@@ -6138,9 +6286,10 @@
       }
     },
     "ndarray": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
-      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "dev": true,
       "requires": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
@@ -6150,45 +6299,32 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
       "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
+      "dev": true,
       "requires": {
         "typedarray-pool": "^1.0.0"
-      }
-    },
-    "ndarray-fill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
-      "integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
-      "requires": {
-        "cwise": "^1.0.10"
       }
     },
     "ndarray-gradient": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
       "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
+      "dev": true,
       "requires": {
         "cwise-compiler": "^1.0.0",
         "dup": "^1.0.0"
       }
     },
-    "ndarray-homography": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
-      "integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
-      "requires": {
-        "gl-matrix-invert": "^1.0.0",
-        "ndarray-warp": "^1.0.0"
-      }
-    },
     "ndarray-linear-interpolate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ndarray-linear-interpolate/-/ndarray-linear-interpolate-1.0.0.tgz",
-      "integrity": "sha1-eLySuFuavBW25n7mWCj54hN65ys="
+      "integrity": "sha1-eLySuFuavBW25n7mWCj54hN65ys=",
+      "dev": true
     },
     "ndarray-ops": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
       "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "dev": true,
       "requires": {
         "cwise-compiler": "^1.0.0"
       }
@@ -6197,6 +6333,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
       "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "dev": true,
       "requires": {
         "cwise-compiler": "^1.1.2",
         "ndarray": "^1.0.13"
@@ -6206,6 +6343,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
       "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
+      "dev": true,
       "requires": {
         "ndarray": "^1.0.14",
         "ndarray-ops": "^1.2.1",
@@ -6216,17 +6354,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
       "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
+      "dev": true,
       "requires": {
         "typedarray-pool": "^1.0.0"
-      }
-    },
-    "ndarray-warp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
-      "integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
-      "requires": {
-        "cwise": "^1.0.4",
-        "ndarray-linear-interpolate": "^1.0.0"
       }
     },
     "negotiator": {
@@ -6244,12 +6374,14 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nextafter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
       "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+      "dev": true,
       "requires": {
         "double-bits": "^1.1.0"
       }
@@ -6405,12 +6537,14 @@
     "normalize-svg-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
-      "integrity": "sha1-RWNg5g7Odfvve11+FgSA5//Rb+U="
+      "integrity": "sha1-RWNg5g7Odfvve11+FgSA5//Rb+U=",
+      "dev": true
     },
     "normals": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
-      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
+      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA=",
+      "dev": true
     },
     "npm-normalize-package-bin": {
       "version": "1.0.1",
@@ -6431,6 +6565,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
+      "dev": true,
       "requires": {
         "is-finite": "^1.0.1"
       }
@@ -6438,12 +6573,14 @@
     "numeric": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
+      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6470,12 +6607,14 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc="
+      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+      "dev": true
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha1-xdLof/nhGfeLegiEQVGeLuwVc7Y=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -6484,7 +6623,8 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6499,6 +6639,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -6540,6 +6681,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6556,7 +6698,8 @@
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -6570,6 +6713,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
       "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
+      "dev": true,
       "requires": {
         "filtered-vector": "^1.2.1",
         "gl-mat4": "^1.0.3"
@@ -6593,35 +6737,13 @@
     "os-homedir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
-      "integrity": "sha1-oMdrsAGoOSpQPL1G5+ZQs0I6kjw="
-    },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
       "dev": true
     },
     "p-limit": {
@@ -6667,6 +6789,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
       "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
+      "dev": true,
       "requires": {
         "repeat-string": "^1.3.0"
       }
@@ -6739,7 +6862,8 @@
     "parenthesis": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.7.tgz",
-      "integrity": "sha1-AcibYDoqaiYuxHVU507RVKm+KqY="
+      "integrity": "sha512-iMtu+HCbLXVrpf6Ys/4YKhcFxbux3xK4ZVB9r+a2kMSqeeQWQoDNYlXIsOjwlT2ldYXZ3k5PVeBnYn7fbAo/Bg==",
+      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.5",
@@ -6764,7 +6888,8 @@
     "parse-rect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
-      "integrity": "sha1-4KWw26qu5jegoeuXeZaeGTmdjew=",
+      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
+      "dev": true,
       "requires": {
         "pick-by-alias": "^1.2.0"
       }
@@ -6778,12 +6903,14 @@
     "parse-svg-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha1-en7A0esG+lMlx9PgCbhZoJtdSes="
+      "integrity": "sha1-en7A0esG+lMlx9PgCbhZoJtdSes=",
+      "dev": true
     },
     "parse-unit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
+      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8=",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -6828,7 +6955,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -6845,7 +6973,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -6856,7 +6985,8 @@
     "pbf": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha1-tMG55yr5Zs2CxlMWkRFcwECf/io=",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dev": true,
       "requires": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -6878,12 +7008,14 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "permutation-parity": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
       "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
+      "dev": true,
       "requires": {
         "typedarray-pool": "^1.0.0"
       }
@@ -6892,6 +7024,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
       "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
+      "dev": true,
       "requires": {
         "invert-permutation": "^1.0.0",
         "typedarray-pool": "^1.0.0"
@@ -6900,7 +7033,8 @@
     "pick-by-alias": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
-      "integrity": "sha1-X3yysfIabh6ISgyHhVqko3NhEHs="
+      "integrity": "sha1-X3yysfIabh6ISgyHhVqko3NhEHs=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.2",
@@ -6942,6 +7076,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
       "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
+      "dev": true,
       "requires": {
         "compare-angle": "^1.0.0",
         "dup": "^1.0.0"
@@ -6951,6 +7086,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
       "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
+      "dev": true,
       "requires": {
         "edges-to-adjacency-list": "^1.0.0",
         "planar-dual": "^1.0.0",
@@ -6962,9 +7098,10 @@
       }
     },
     "plotly.js": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.54.1.tgz",
-      "integrity": "sha512-1tlsEQkUgX2BaQr3Eu+5drki3eyor5EhpolFRteuQouRFX9mrg9Pms39Lak29lbAx4W3ZQoCZm8DcKkQCOe9YQ==",
+      "version": "1.54.5",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.54.5.tgz",
+      "integrity": "sha512-eO1CuPJxRoKUH18sGDaU47dfXnFWmYrb+JQrU0keGZRevII+DTsM/0gaSs0hTxgvnJ0otAaR6JONZqsgn9ca6Q==",
+      "dev": true,
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
@@ -6991,8 +7128,8 @@
         "gl-line3d": "1.2.1",
         "gl-mat4": "^1.2.0",
         "gl-mesh3d": "^2.3.1",
-        "gl-plot2d": "^1.4.4",
-        "gl-plot3d": "^2.4.5",
+        "gl-plot2d": "^1.4.5",
+        "gl-plot3d": "^2.4.6",
         "gl-pointcloud2d": "^1.0.3",
         "gl-scatter3d": "^1.2.3",
         "gl-select-box": "^1.0.4",
@@ -7004,18 +7141,17 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^2.2.1",
-        "mapbox-gl": "1.10.0",
+        "mapbox-gl": "1.10.1",
         "matrix-camera-controller": "^2.1.3",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
-        "ndarray": "1.0.18",
-        "ndarray-fill": "^1.0.2",
-        "ndarray-homography": "^1.0.0",
+        "ndarray": "^1.0.19",
+        "ndarray-linear-interpolate": "^1.0.0",
         "parse-svg-path": "^0.1.2",
         "point-cluster": "^3.1.8",
         "polybooljs": "^1.2.0",
-        "regl": "1.3.11",
+        "regl": "^1.6.1",
         "regl-error2d": "^2.0.8",
         "regl-line2d": "^3.0.15",
         "regl-scatter2d": "^3.1.8",
@@ -7036,7 +7172,8 @@
     "point-cluster": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.8.tgz",
-      "integrity": "sha1-pjYl/Ylk8qW0RgJaGs+LysQlAMA=",
+      "integrity": "sha512-7klIr45dpMeZuqjIK9+qBg3m2IhyZJNJkdqjJFw0Olq75FM8ojrTMjClVUrMjNYRVqtwztxCHH71Fyjhg+YwyQ==",
+      "dev": true,
       "requires": {
         "array-bounds": "^1.0.1",
         "array-normalize": "^1.1.4",
@@ -7056,6 +7193,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
       "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^1.0.0",
         "interval-tree-1d": "^1.0.1",
@@ -7066,19 +7204,22 @@
         "binary-search-bounds": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k=",
+          "dev": true
         }
       }
     },
     "polybooljs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
-      "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g="
+      "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g=",
+      "dev": true
     },
     "polytope-closest-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
       "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
+      "dev": true,
       "requires": {
         "numeric": "^1.2.6"
       }
@@ -7131,7 +7272,7 @@
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -7142,7 +7283,7 @@
     "postcss-modules-extract-imports": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-      "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.5"
@@ -7151,7 +7292,7 @@
     "postcss-modules-local-by-default": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
-      "integrity": "sha1-6KZWG+kUqvPAUodjd1JMqQ27eRU=",
+      "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
       "dev": true,
       "requires": {
         "icss-utils": "^4.1.1",
@@ -7163,7 +7304,7 @@
     "postcss-modules-scope": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-      "integrity": "sha1-OFyuATzHdD9afXYC0Qc6iequYu4=",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.6",
@@ -7173,7 +7314,7 @@
     "postcss-modules-values": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-      "integrity": "sha1-W1AA1uuuKbQlUwG0o6VFdEI+fxA=",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "requires": {
         "icss-utils": "^4.0.0",
@@ -7183,7 +7324,7 @@
     "postcss-selector-parser": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-      "integrity": "sha1-k0z3mdAWyDQRhZ4J3Oyt4BKG7Fw=",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -7194,18 +7335,20 @@
     "postcss-value-parser": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss=",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
     "potpack": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
-      "integrity": "sha1-0bGv2J5Mj3dihl7DC9ESq3Z+Lr8="
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -7216,12 +7359,13 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -7233,7 +7377,8 @@
     "protocol-buffers-schema": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
-      "integrity": "sha1-Lw6jHKlmJ9aAvy/vrn6/orZFPq4="
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -7307,7 +7452,8 @@
     "pxls": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
-      "integrity": "sha1-eRANLMlQifxuAAU6nZPB3d2yx7Q=",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
+      "dev": true,
       "requires": {
         "arr-flatten": "^1.1.0",
         "compute-dims": "^1.1.0",
@@ -7320,7 +7466,8 @@
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
         }
       }
     },
@@ -7333,12 +7480,14 @@
     "quantize": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
-      "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4="
+      "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4=",
+      "dev": true
     },
     "quat-slerp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
       "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
+      "dev": true,
       "requires": {
         "gl-quat": "^1.0.0"
       }
@@ -7364,50 +7513,14 @@
     "quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha1-8ZaApIal7vtYEwPgI+mPqvJd0Bg="
-    },
-    "quote-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
-      "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
-      "requires": {
-        "minimist": "0.0.8",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "dev": true
     },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -7441,6 +7554,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
       "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+      "dev": true,
       "requires": {
         "big-rat": "^1.0.3"
       }
@@ -7482,6 +7596,7 @@
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -7512,6 +7627,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
+      "dev": true,
       "requires": {
         "cell-orientation": "^1.0.1",
         "compare-cell": "^1.0.0",
@@ -7519,14 +7635,16 @@
       }
     },
     "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+      "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+      "dev": true
     },
     "regenerate-unicode-properties": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
+      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+      "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
@@ -7544,12 +7662,14 @@
     "regex-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regex-regex/-/regex-regex-1.0.0.tgz",
-      "integrity": "sha1-kEih6uuHD01IDavHb8Qs3MC8OnI="
+      "integrity": "sha1-kEih6uuHD01IDavHb8Qs3MC8OnI=",
+      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha1-erqJs8E6ZFCdq888qNn7ub31y3U=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -7558,7 +7678,8 @@
     "regexpu-core": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha1-/L9FjFBDGwu3tF1pZ7gZLZHz2Tg=",
+      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+      "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.2.0",
@@ -7571,25 +7692,29 @@
     "regjsgen": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-      "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
+      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       }
     },
     "regl": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.11.tgz",
-      "integrity": "sha512-tmt6CRhRqbcsYDWNwv+iG7GGOXdgoOBC7lKzoPMgnzpt3WKBQ3c8i7AxgbvTRZzty29hrW92fAJeZkPFQehfWA=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.6.1.tgz",
+      "integrity": "sha512-7Z9rmpEqmLNwC9kCYCyfyu47eWZaQWeNpwZfwz99QueXN8B/Ow40DB0N+OeUeM/yu9pZAB01+JgJ+XghGveVoA==",
+      "dev": true
     },
     "regl-error2d": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.8.tgz",
-      "integrity": "sha1-DyY3HumceNQunFoZc4fjIDS89kA=",
+      "integrity": "sha512-5nszdicXbimRUnYB42i+O7KPcla7PzI62nZLCP6qVRKlQCf3rSrWbikMNd1S84LE8+deWHWcb8rZ/v7rZ9qmmw==",
+      "dev": true,
       "requires": {
         "array-bounds": "^1.0.1",
         "bubleify": "^1.2.0",
@@ -7604,7 +7729,8 @@
     "regl-line2d": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.15.tgz",
-      "integrity": "sha1-W68qDtUCTOwuwDjGraYByYrFeeM=",
+      "integrity": "sha512-RuQbg9iZ6MyuInG8izF6zjQ/2g4qL6sg1egiuFalWzaGSvuve/IWBsIcqKTlwpiEsRt9b4cHu9NYs2fLt1gYJw==",
+      "dev": true,
       "requires": {
         "array-bounds": "^1.0.1",
         "array-normalize": "^1.1.4",
@@ -7623,7 +7749,8 @@
     "regl-scatter2d": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.8.tgz",
-      "integrity": "sha1-X993+c7n5xSX0DjcG2VNxDQLa/s=",
+      "integrity": "sha512-Z9MYAUx9t8e3MsiHBbJAEstbIqauXxzcL9DmuKXQuRWfCMF2DBytYJtE0FpbQU6639wEMAJ54SEIlISWF8sQ2g==",
+      "dev": true,
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",
@@ -7646,7 +7773,8 @@
     "regl-splom": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.8.tgz",
-      "integrity": "sha1-BfFlpvC4r8a2uX+vp3UoLUQ4fbM=",
+      "integrity": "sha512-4GQTgcArCbGLsXhgalWVBxeW7OXllnu+Gvil/4SbQQmtiqLCl+xgF79pISKY9mLXTlobxiX7cVKdjGjp25559A==",
+      "dev": true,
       "requires": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
@@ -7683,7 +7811,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -7707,6 +7836,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -7733,7 +7863,7 @@
         "global-modules": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
@@ -7752,7 +7882,8 @@
     "resolve-protobuf-schema": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-      "integrity": "sha1-nKmp5pzxkrva8QBuwZc5SKpKN1g=",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dev": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -7767,6 +7898,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
       "requires": {
         "through": "~2.3.4"
       }
@@ -7783,18 +7915,11 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "right-now": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
-      "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
+      "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg=",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -7818,12 +7943,14 @@
     "robust-compress": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
-      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs="
+      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs=",
+      "dev": true
     },
     "robust-determinant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
       "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
+      "dev": true,
       "requires": {
         "robust-compress": "^1.0.0",
         "robust-scale": "^1.0.0",
@@ -7835,6 +7962,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
       "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
+      "dev": true,
       "requires": {
         "robust-sum": "^1.0.0",
         "two-product": "^1.0.0"
@@ -7844,6 +7972,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
       "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
+      "dev": true,
       "requires": {
         "robust-scale": "^1.0.0",
         "robust-subtract": "^1.0.0",
@@ -7855,6 +7984,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
       "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
+      "dev": true,
       "requires": {
         "robust-determinant": "^1.1.0"
       }
@@ -7863,6 +7993,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "dev": true,
       "requires": {
         "robust-scale": "^1.0.2",
         "robust-subtract": "^1.0.0",
@@ -7874,6 +8005,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
       "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
+      "dev": true,
       "requires": {
         "robust-scale": "^1.0.0",
         "robust-sum": "^1.0.0"
@@ -7883,6 +8015,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "dev": true,
       "requires": {
         "two-product": "^1.0.2",
         "two-sum": "^1.0.0"
@@ -7892,6 +8025,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
       "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+      "dev": true,
       "requires": {
         "robust-orientation": "^1.1.3"
       }
@@ -7899,12 +8033,14 @@
     "robust-subtract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
-      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo=",
+      "dev": true
     },
     "robust-sum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
-      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k=",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -7918,12 +8054,14 @@
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -7943,7 +8081,8 @@
     "sane-topojson": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-4.0.0.tgz",
-      "integrity": "sha1-YkzbJvxtk5LIBol7/Ro5Pym7Uwg="
+      "integrity": "sha512-bJILrpBboQfabG3BNnHI2hZl52pbt80BE09u4WhnrmzuF2JbMKZdl62G5glXskJ46p+gxE2IzOwGj/awR4g8AA==",
+      "dev": true
     },
     "schema-utils": {
       "version": "2.7.0",
@@ -8119,7 +8258,8 @@
     "shallow-copy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -8139,7 +8279,7 @@
     "shelljs": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -8156,12 +8296,14 @@
     "signum": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
-      "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+      "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY=",
+      "dev": true
     },
     "simplicial-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.0",
         "union-find": "^1.0.0"
@@ -8171,6 +8313,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
       "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
+      "dev": true,
       "requires": {
         "boundary-cells": "^2.0.0",
         "reduce-simplicial-complex": "^1.0.0"
@@ -8180,6 +8323,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
       "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
+      "dev": true,
       "requires": {
         "marching-simplex-table": "^1.0.0",
         "ndarray": "^1.0.15",
@@ -8191,6 +8335,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
       "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
+      "dev": true,
       "requires": {
         "robust-orientation": "^1.0.1",
         "simplicial-complex": "^0.3.3"
@@ -8199,12 +8344,14 @@
         "bit-twiddle": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-0.0.2.tgz",
-          "integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4="
+          "integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4=",
+          "dev": true
         },
         "simplicial-complex": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
           "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
+          "dev": true,
           "requires": {
             "bit-twiddle": "~0.0.1",
             "union-find": "~0.0.3"
@@ -8213,7 +8360,8 @@
         "union-find": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/union-find/-/union-find-0.0.4.tgz",
-          "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY="
+          "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY=",
+          "dev": true
         }
       }
     },
@@ -8221,6 +8369,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
       "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
+      "dev": true,
       "requires": {
         "binary-search-bounds": "^1.0.0",
         "functional-red-black-tree": "^1.0.0",
@@ -8230,7 +8379,8 @@
         "binary-search-bounds": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k=",
+          "dev": true
         }
       }
     },
@@ -8402,7 +8552,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -8436,7 +8587,8 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -8555,6 +8707,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
       "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
+      "dev": true,
       "requires": {
         "robust-dot-product": "^1.0.0",
         "robust-sum": "^1.0.0"
@@ -8572,7 +8725,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "ssri": {
       "version": "6.0.1",
@@ -8586,12 +8740,14 @@
     "stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+      "dev": true
     },
     "static-eval": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.5.tgz",
-      "integrity": "sha1-8HguZpmcSzZRzamdnOWcUH0Yj3E=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+      "dev": true,
       "requires": {
         "escodegen": "^1.11.1"
       }
@@ -8613,118 +8769,6 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
-          }
-        }
-      }
-    },
-    "static-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
-      "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
-      "requires": {
-        "concat-stream": "~1.6.0",
-        "duplexer2": "~0.0.2",
-        "escodegen": "~1.3.2",
-        "falafel": "^2.1.0",
-        "has": "^1.0.0",
-        "object-inspect": "~0.4.0",
-        "quote-stream": "~0.0.0",
-        "readable-stream": "~1.0.27-1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "~0.2.0",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-          "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
-          "requires": {
-            "esprima": "~1.1.1",
-            "estraverse": "~1.5.0",
-            "esutils": "~1.0.0",
-            "source-map": "~0.1.33"
-          }
-        },
-        "esprima": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-          "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
-        },
-        "estraverse": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-          "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
-        },
-        "esutils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
-        },
-        "object-inspect": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-          "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "static-eval": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
-          "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
-          "requires": {
-            "escodegen": "~0.0.24"
-          },
-          "dependencies": {
-            "escodegen": {
-              "version": "0.0.28",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
-              "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
-              "requires": {
-                "esprima": "~1.0.2",
-                "estraverse": "~1.3.0",
-                "source-map": ">= 0.1.2"
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-            },
-            "estraverse": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-              "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
-            }
-          }
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
           }
         }
       }
@@ -8847,12 +8891,14 @@
     "stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0="
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
+      "dev": true
     },
     "string-split-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
-      "integrity": "sha1-U4lfszl+vGCtqx8eOhMfU3JYaBI=",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "dev": true,
       "requires": {
         "parenthesis": "^3.1.5"
       }
@@ -8860,7 +8906,8 @@
     "string-to-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
-      "integrity": "sha1-FhFH+63qAuKLCTUALOxMQPHKfwo=",
+      "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
+      "dev": true,
       "requires": {
         "atob-lite": "^2.0.0",
         "is-base64": "^0.1.0"
@@ -8869,7 +8916,8 @@
         "atob-lite": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-          "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+          "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+          "dev": true
         }
       }
     },
@@ -8887,7 +8935,8 @@
     "string.prototype.trim": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
-      "integrity": "sha1-FBIz3/Msgr+tgGhNfl8Iae4Pt4I=",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -8898,6 +8947,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -8907,6 +8957,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
       "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -8917,6 +8968,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
       "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -8927,6 +8979,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -8935,7 +8988,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "5.2.0",
@@ -8955,7 +9009,8 @@
     "strongly-connected-components": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
-      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
+      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk=",
+      "dev": true
     },
     "style-loader": {
       "version": "1.2.1",
@@ -8993,6 +9048,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
       "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
+      "dev": true,
       "requires": {
         "kdbush": "^3.0.0"
       }
@@ -9000,12 +9056,14 @@
     "superscript-text": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
+      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -9014,6 +9072,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
       "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
+      "dev": true,
       "requires": {
         "ndarray-extract-contour": "^1.0.0",
         "triangulate-hypercube": "^1.0.0",
@@ -9023,12 +9082,14 @@
     "svg-arc-to-cubic-bezier": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha1-OQxFADWuHEoBBNkGUDBMO8gUq+Y="
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "dev": true
     },
     "svg-path-bounds": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.1.tgz",
       "integrity": "sha1-v0WLeDcmv1NDG0Yz8nkvYHSNn3Q=",
+      "dev": true,
       "requires": {
         "abs-svg-path": "^0.1.1",
         "is-svg-path": "^1.0.1",
@@ -9040,6 +9101,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.0.1.tgz",
           "integrity": "sha1-b3Ka1rcLtMpO/y/ksQdInv4dVv4=",
+          "dev": true,
           "requires": {
             "svg-arc-to-cubic-bezier": "^3.0.0"
           }
@@ -9049,7 +9111,8 @@
     "svg-path-sdf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
-      "integrity": "sha1-kpV6MXhMDq9olFRyyNxr+ebRJvw=",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
+      "dev": true,
       "requires": {
         "bitmap-sdf": "^1.0.0",
         "draw-svg-path": "^1.0.0",
@@ -9068,6 +9131,7 @@
       "version": "4.13.3",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
       "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
+      "dev": true,
       "requires": {
         "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
@@ -9130,7 +9194,8 @@
     "text-cache": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.2.2.tgz",
-      "integrity": "sha1-0NMLqJtzEuocGjHNmk21bBzvf+c=",
+      "integrity": "sha512-zky+UDYiX0a/aPw/YTBD+EzKMlCTu1chFuCMZeAkgoRiceySdROu1V2kJXhCbtEdBhiOviYnAdGiSYl58HW0ZQ==",
+      "dev": true,
       "requires": {
         "vectorize-text": "^3.2.1"
       }
@@ -9138,12 +9203,14 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -9167,12 +9234,14 @@
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+      "dev": true
     },
     "tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha1-ZNhJLr8554Ade9NAYuKbRbIDXwg="
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "dev": true
     },
     "tmp": {
       "version": "0.2.1",
@@ -9186,7 +9255,8 @@
     "to-array-buffer": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
-      "integrity": "sha1-y2hN1pGnNow7JJwjSNdSJ/fU27Q=",
+      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
+      "dev": true,
       "requires": {
         "flatten-vertex-data": "^1.0.2",
         "is-blob": "^2.0.1",
@@ -9202,7 +9272,8 @@
     "to-float32": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.0.1.tgz",
-      "integrity": "sha1-ItWSHzgYMWS55+mHYVjAwWy5dTo="
+      "integrity": "sha512-nOy2WSwae3xhZbc+05xiCuU3ZPPmH0L4Rg4Q1qiOGFSuNSCTB9nVJaGgGl3ZScxAclX/L8hJuDHJGDAzbfuKCQ==",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -9217,6 +9288,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
       "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
+      "dev": true,
       "requires": {
         "parse-unit": "^1.0.1"
       }
@@ -9245,7 +9317,8 @@
     "to-uint8": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
-      "integrity": "sha1-n0VpSQW4J/JH03vI7IOygY2B+sk=",
+      "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
+      "dev": true,
       "requires": {
         "arr-flatten": "^1.1.0",
         "clamp": "^1.0.1",
@@ -9264,6 +9337,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dev": true,
       "requires": {
         "commander": "2"
       }
@@ -9272,6 +9346,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
       "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
+      "dev": true,
       "requires": {
         "gamma": "^0.1.0",
         "permutation-parity": "^1.0.0",
@@ -9282,14 +9357,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
       "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
+      "dev": true,
       "requires": {
         "cdt2d": "^1.0.0"
       }
     },
     "ts-loader": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-      "integrity": "sha1-3/o4ebAaGh4KS4XiuEIdwN//HFg=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.0.tgz",
+      "integrity": "sha512-giEW167rtK1V6eX/DnXEtOgcawwoIp6hqznqYNNSmraUZOq36zMhwBq12JMlYhxf50BC58bscsTSKKtE42zAuw==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -9366,6 +9442,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
       "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
+      "dev": true,
       "requires": {
         "filtered-vector": "^1.2.1",
         "gl-mat4": "^1.0.2",
@@ -9375,22 +9452,26 @@
     "two-product": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
-      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo=",
+      "dev": true
     },
     "two-sum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
-      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q=",
+      "dev": true
     },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -9408,26 +9489,29 @@
     "type-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
-      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
+      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typedarray-pool": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
-      "integrity": "sha1-5+kHIBRLoCue1mBDivbzqs/jOsM=",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
       }
     },
     "typedoc": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
-      "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
       "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
@@ -9439,22 +9523,22 @@
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.10.1"
+        "typedoc-default-themes": "^0.10.2"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
-      "integrity": "sha1-6ye31olFfH7IQ+R+wNPlAFgSlqc=",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.8"
       }
     },
     "typedoc-plugin-external-module-name": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-3.1.0.tgz",
-      "integrity": "sha1-PC3HLub6UR797iH59HAUClxpBCs=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.3.tgz",
+      "integrity": "sha512-2PjEN9kdmkB7NxN3DEax6yDIPjq7HV8qELQhkSRJGxJs/8G/ZwPPvXT0z6hUqtWVr6MeCjpAoYJFzHo04C14Aw==",
       "dev": true,
       "requires": {
         "lodash": "^4.1.2",
@@ -9464,54 +9548,41 @@
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha1-nEEagCpAmpH8bPdAgbq6NLJEmaw="
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "dev": true,
       "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg="
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
         "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -9520,17 +9591,20 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-      "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE="
+      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+      "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-      "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ="
+      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
+      "dev": true
     },
     "union-find": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
-      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg=",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -9547,7 +9621,8 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -9570,7 +9645,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unpipe": {
@@ -9582,7 +9657,8 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -9639,7 +9715,8 @@
     "update-diff": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
-      "integrity": "sha1-9RAYLYHugZ+4LDprIrYrve2ngI8="
+      "integrity": "sha1-9RAYLYHugZ+4LDprIrYrve2ngI8=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -9710,12 +9787,14 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-copy": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
       "integrity": "sha1-biuXmCqozXPhGCo+b4vsPA9AWKc=",
+      "dev": true,
       "requires": {
         "const-pinf-float64": "^1.0.0",
         "object-keys": "^1.0.9",
@@ -9732,6 +9811,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
       "integrity": "sha1-eR3jk8DwmJCv1Z88vqY18HmpT6U=",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.9",
         "utils-copy": "^1.1.0"
@@ -9741,6 +9821,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
       "integrity": "sha1-IP6r8J7xAYtSNkPoOA57yD7GG1w=",
+      "dev": true,
       "requires": {
         "validate.io-array-like": "^1.0.1",
         "validate.io-integer-primitive": "^1.0.0"
@@ -9756,6 +9837,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
       "integrity": "sha1-/hopCfjeD/DVGCyA+8ZU1qaH0Yk=",
+      "dev": true,
       "requires": {
         "regex-regex": "^1.0.0",
         "validate.io-string-primitive": "^1.0.0"
@@ -9768,9 +9850,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-      "integrity": "sha1-APdJTSritojP4omd9u0sVL75Hb4=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -9786,12 +9868,14 @@
     "validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
+      "dev": true
     },
     "validate.io-array-like": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
       "integrity": "sha1-evn363tRcVvrIhVmjsXM5U+t21o=",
+      "dev": true,
       "requires": {
         "const-max-uint32": "^1.0.2",
         "validate.io-integer-primitive": "^1.0.0"
@@ -9800,12 +9884,14 @@
     "validate.io-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-buffer/-/validate.io-buffer-1.0.2.tgz",
-      "integrity": "sha1-hS1nNAIZFNXROvwyUxdh43IO1E4="
+      "integrity": "sha1-hS1nNAIZFNXROvwyUxdh43IO1E4=",
+      "dev": true
     },
     "validate.io-integer": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
       "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "dev": true,
       "requires": {
         "validate.io-number": "^1.0.3"
       }
@@ -9814,6 +9900,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
       "integrity": "sha1-qaoBA1X+hoHA/qbBp0rSQZyt3cY=",
+      "dev": true,
       "requires": {
         "validate.io-number-primitive": "^1.0.0"
       }
@@ -9821,17 +9908,20 @@
     "validate.io-matrix-like": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-matrix-like/-/validate.io-matrix-like-1.0.2.tgz",
-      "integrity": "sha1-XsMqddCInaxzbepovdYUWxVe38M="
+      "integrity": "sha1-XsMqddCInaxzbepovdYUWxVe38M=",
+      "dev": true
     },
     "validate.io-ndarray-like": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-ndarray-like/-/validate.io-ndarray-like-1.0.0.tgz",
-      "integrity": "sha1-2KOw7RZbvx0vwNAHMnDPpVIpWRk="
+      "integrity": "sha1-2KOw7RZbvx0vwNAHMnDPpVIpWRk=",
+      "dev": true
     },
     "validate.io-nonnegative-integer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
       "integrity": "sha1-gGkkOgjF+Y6VQTySnf17GPP28p8=",
+      "dev": true,
       "requires": {
         "validate.io-integer": "^1.0.5"
       }
@@ -9839,17 +9929,20 @@
     "validate.io-number": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
+      "dev": true
     },
     "validate.io-number-primitive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-number-primitive/-/validate.io-number-primitive-1.0.0.tgz",
-      "integrity": "sha1-0uAfICmJNp3PEVVElWQgOv5YTlU="
+      "integrity": "sha1-0uAfICmJNp3PEVVElWQgOv5YTlU=",
+      "dev": true
     },
     "validate.io-positive-integer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
       "integrity": "sha1-ftLQO0wnVYzGagCqsPDpIYFKZYI=",
+      "dev": true,
       "requires": {
         "validate.io-integer": "^1.0.5"
       }
@@ -9857,7 +9950,8 @@
     "validate.io-string-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/validate.io-string-primitive/-/validate.io-string-primitive-1.0.1.tgz",
-      "integrity": "sha1-uBNbn7E3K94C/dU60dDM1t55j+4="
+      "integrity": "sha1-uBNbn7E3K94C/dU60dDM1t55j+4=",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -9868,7 +9962,8 @@
     "vectorize-text": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.1.tgz",
-      "integrity": "sha1-hZIavZaFr3df0goBBBooN/5RvbU=",
+      "integrity": "sha512-rGojF+D9BB96iPZPUitfq5kaiS6eCJmfEel0NXOK/MzZSuXGiwhoop80PtaDas9/Hg/oaox1tI9g3h93qpuspg==",
+      "dev": true,
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",
@@ -9888,7 +9983,8 @@
     "vt-pbf": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
-      "integrity": "sha1-sPYn45oQzpHZQ7iY7SNj0hiZ+4I=",
+      "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
+      "dev": true,
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -10196,17 +10292,20 @@
     "weak-map": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
-      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=",
+      "dev": true
     },
     "weakmap-shim": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
-      "integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k="
+      "integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k=",
+      "dev": true
     },
     "webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
+      "dev": true,
       "requires": {
         "get-canvas-context": "^1.0.1"
       }
@@ -10417,141 +10516,31 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
-      "integrity": "sha1-O/IYib9Ze12Cw48hUTWkEe39xjE=",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.12.tgz",
+      "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "enhanced-resolve": "4.1.0",
-        "findup-sync": "3.0.0",
-        "global-modules": "2.0.0",
-        "import-local": "2.0.0",
-        "interpret": "1.2.0",
-        "loader-utils": "1.2.3",
-        "supports-color": "6.1.0",
-        "v8-compile-cache": "2.0.3",
-        "yargs": "13.2.4"
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "enhanced-resolve": "^4.1.1",
+        "findup-sync": "^3.0.0",
+        "global-modules": "^2.0.0",
+        "import-local": "^2.0.0",
+        "interpret": "^1.4.0",
+        "loader-utils": "^1.4.0",
+        "supports-color": "^6.1.0",
+        "v8-compile-cache": "^2.1.1",
+        "yargs": "^13.3.2"
       },
       "dependencies": {
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-          "dev": true
-        },
-        "enhanced-resolve": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-          "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.4.0",
-            "tapable": "^1.0.0"
-          }
-        },
-        "interpret": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "memory-fs": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-          "dev": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-          "integrity": "sha1-C1YreUAW65ZRuYvTes82SqXW3IM=",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
           }
         }
       }
@@ -11065,20 +11054,17 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -11093,6 +11079,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
       "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.0"
       }
@@ -11111,7 +11098,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "6.2.1",
@@ -11125,7 +11113,8 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",
@@ -11140,14 +11129,21 @@
       "dev": true
     },
     "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
       }
     },
     "yargs-parser": {
@@ -11178,6 +11174,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
       "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
+      "dev": true,
       "requires": {
         "cwise-compiler": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,31 +24,29 @@
     "lint": "tslint -c tslint.json src/*.ts"
   },
   "devDependencies": {
-    "@types/markdown-it": "0.0.9",
-    "@types/node": "^13.13.9",
-    "@types/plotly.js": "^1.50.12",
+    "@types/markdown-it": "^10.0.1",
+    "@types/node": "^14.0.0",
+    "@types/plotly.js": "^1.50.14",
     "@types/tmp": "^0.2.0",
-    "@types/webpack": "^4.41.13",
+    "@types/webpack": "^4.41.21",
     "@types/webpack-merge": "^4.1.5",
-    "css-loader": "^3.5.3",
+    "css-loader": "^3.6.0",
     "dts-bundle": "^0.7.3",
     "html-loader": "^1.1.0",
     "ify-loader": "^1.1.0",
+    "markdown-it": "^11.0.0",
+    "plotly.js": "^1.54.5",
     "style-loader": "^1.2.1",
     "tmp": "^0.2.1",
-    "ts-loader": "^6.2.2",
+    "ts-loader": "^8.0.0",
     "ts-node": "^8.10.1",
     "tslint": "^6.1.2",
-    "typedoc": "^0.17.7",
-    "typedoc-plugin-external-module-name": "^3.1.0",
-    "typescript": "^3.9.3",
+    "typedoc": "^0.17.8",
+    "typedoc-plugin-external-module-name": "^4",
+    "typescript": "^3.9.6",
     "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11",
+    "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
-    "webpack-merge": "^4.2.2"
-  },
-  "dependencies": {
-    "markdown-it": "^10.0.0",
-    "plotly.js": "^1.54.1"
+    "webpack-merge": "^4.0"
   }
 }


### PR DESCRIPTION
Since we are bundling everything in chemiscope.min.js, users of chemiscope do not need to install these