### PR TITLE
Fix id replace in structure viewer options

### DIFF
--- a/src/structure/options.html
+++ b/src/structure/options.html
@@ -88,8 +88,9 @@
                                 for="env-center"
                                 title="center automatically structure or environment in the viewport"
                                 style="cursor: help;"
-                                >center</label
                             >
+                                center
+                            </label>
                         </div>
                         <button
                             class="btn btn-sm btn-secondary chsp-extra-options-btn"
@@ -156,9 +157,14 @@
                     <div class="chsp-settings-trajectory">
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="playback-delay" title="playback delay in tenths of seconds" style="cursor: help;"
-                                    >playback delay</label
+                                <label
+                                    class="input-group-text"
+                                    for="playback-delay"
+                                    title="playback delay in tenths of seconds"
+                                    style="cursor: help;"
                                 >
+                                    playback delay
+                                </label>
                             </div>
                             <input id="playback-delay" class="form-control" type="number" min="1" value="7" />
                         </div>
@@ -169,8 +175,9 @@
                                 for="keep-orientation"
                                 title="keep the camera orientation when loading a new molecule"
                                 style="cursor: help;"
-                                >keep orientation</label
                             >
+                                keep orientation
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -146,15 +146,11 @@ export class StructureOptions extends OptionsGroup {
 
         // replace id to ensure they are unique even if we have mulitple viewers
         // on a single page
-        template.innerHTML = HTML_OPTIONS.replace(
-            /id=(.*?) /g,
-            (_: string, id: string) => `id=${guid}-${id} `
-        )
-            .replace(/for=(.*?) /g, (_: string, id: string) => `for=${guid}-${id} `)
-            .replace(
-                /data-target=#(.*?) /g,
-                (_: string, id: string) => `data-target=#${guid}-${id} `
-            );
+        // prettier-ignore
+        template.innerHTML = HTML_OPTIONS
+            .replace(/id="(.*?)"/g, (_: string, id: string) => `id="${guid}-${id}"`)
+            .replace(/for="(.*?)"/g, (_: string, id: string) => `for="${guid}-${id}"`)
+            .replace(/data-target=#(.*?)/g, (_: string, id: string) => `data-target=#${guid}-${id}`);
 
         const modal = template.content.firstChild as HTMLElement;
         const modalDialog = modal.childNodes[1] as HTMLElement;


### PR DESCRIPTION
HTML formatting by prettier added unexpected double quotes around the id.

Extracted from #80 since it is useful by itself.