### PR TITLE
Add properties metadata

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -125,6 +125,10 @@ export interface Property {
      * or "C"); and numeric values should be use for everything else.
      */
     values: string[] | number[];
+    /** string containing the description of the property */
+    description?: string;
+    /** string containing the units of the property */
+    units?: string;
 }
 
 /**
@@ -322,6 +326,15 @@ function checkProperties(
             if (typeof value !== initial) {
                 throw Error(`'properties['${key}'].values' should be of a single type`);
             }
+        }
+
+        // check the meta is valid
+        if ('description' in property && typeof property.description !== 'string') {
+            throw Error(`'properties['${key}'].description' should contain string`);
+        }
+
+        if ('units' in property && typeof property.units !== 'string') {
+            throw Error(`'properties['${key}'].units' should contain string`);
         }
     }
 }

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -125,9 +125,9 @@ export interface Property {
      * or "C"); and numeric values should be use for everything else.
      */
     values: string[] | number[];
-    /** string containing the description of the property */
+    /** user-facing description of the property */
     description?: string;
-    /** string containing the units of the property */
+    /** unit of the property values */
     units?: string;
 }
 
@@ -328,13 +328,13 @@ function checkProperties(
             }
         }
 
-        // check the meta is valid
+        // check that units & description are valid
         if ('description' in property && typeof property.description !== 'string') {
-            throw Error(`'properties['${key}'].description' should contain string`);
+            throw Error(`'properties['${key}'].description' should contain a string`);
         }
 
         if ('units' in property && typeof property.units !== 'string') {
-            throw Error(`'properties['${key}'].units' should contain string`);
+            throw Error(`'properties['${key}'].units' should contain a string`);
         }
     }
 }

--- a/src/info/table.ts
+++ b/src/info/table.ts
@@ -55,7 +55,23 @@ export class Table {
         for (const name in properties) {
             const tr = document.createElement('tr');
             const td = document.createElement('td');
-            td.innerText = name;
+
+            //  add the units to the property if it exists, this is identical to the _title in ../map/map.ts
+            const units = properties[name].units;
+            let title = name;
+            if (units !== undefined) {
+                title += ` [${units}]`;
+            }
+            td.innerText = title;
+
+            // add a tooltip containing the description of the property and underline if it exists
+            const description = properties[name].description;
+            if (description !== undefined) {
+                td.style.borderBottom = '1px dotted #00f';
+                td.style.display = 'inline';
+                td.title = description;
+            }
+
             tr.appendChild(td);
             const cell = document.createElement('td');
             tr.appendChild(cell);

--- a/src/info/table.ts
+++ b/src/info/table.ts
@@ -60,7 +60,7 @@ export class Table {
             const units = properties[name].units;
             let title = name;
             if (units !== undefined) {
-                title += ` [${units}]`;
+                title += `/${units}`;
             }
             td.innerText = title;
 

--- a/src/info/table.ts
+++ b/src/info/table.ts
@@ -68,6 +68,7 @@ export class Table {
             const description = properties[name].description;
             if (description !== undefined) {
                 td.style.borderBottom = '1px dotted #00f';
+                td.style.cursor = "help"
                 td.style.display = 'inline';
                 td.title = description;
             }

--- a/src/info/table.ts
+++ b/src/info/table.ts
@@ -68,7 +68,7 @@ export class Table {
             const description = properties[name].description;
             if (description !== undefined) {
                 td.style.borderBottom = '1px dotted #00f';
-                td.style.cursor = "help"
+                td.style.cursor = 'help';
                 td.style.display = 'inline';
                 td.title = description;
             }

--- a/src/map/data.ts
+++ b/src/map/data.ts
@@ -1,3 +1,5 @@
+import { getUnpackedSettings } from 'http2';
+import { PropertiesMap } from '..';
 /**
  * @packageDocumentation
  * @module map
@@ -14,6 +16,8 @@ export interface NumericProperty {
     values: number[];
     /** string interner if the property was a string-valued property */
     string?: StringInterner;
+    /** add units as optinal*/
+    units?: string;
 }
 
 /** @hidden
@@ -54,16 +58,18 @@ export class StringInterner {
 }
 
 /** Transform a property to a numeric property */
-function propertyToNumeric(name: string, property: number[] | string[]): NumericProperty {
-    const prop_type = typeof property[0];
+function propertyToNumeric(name: string, property: Property): NumericProperty {
+    //console.log(name, property.units);
+    const prop_type = typeof property.values[0];
     if (prop_type === 'number') {
         return {
-            values: property as number[],
+            values: property.values as number[],
+            units: property.units,
         };
     } else if (prop_type === 'string') {
         const interner = new StringInterner();
         const values = [];
-        for (const value of property as string[]) {
+        for (const value of property.values as string[]) {
             const numeric = interner.get(value);
             values.push(numeric);
             // string properties are assumed to be categories, and each one of
@@ -81,6 +87,7 @@ function propertyToNumeric(name: string, property: number[] | string[]): Numeric
         return {
             string: interner,
             values: values,
+            units: property.units,
         };
     } else {
         throw Error(`unexpected property type '${prop_type}'`);
@@ -137,7 +144,7 @@ export class MapData {
         for (const name in properties) {
             let property;
             try {
-                property = propertyToNumeric(name, properties[name].values);
+                property = propertyToNumeric(name, properties[name]);
             } catch (e) {
                 sendWarning(`warning: ${(e as Error).message}`);
                 continue;

--- a/src/map/data.ts
+++ b/src/map/data.ts
@@ -1,5 +1,3 @@
-import { getUnpackedSettings } from 'http2';
-import { PropertiesMap } from '..';
 /**
  * @packageDocumentation
  * @module map
@@ -16,7 +14,7 @@ export interface NumericProperty {
     values: number[];
     /** string interner if the property was a string-valued property */
     string?: StringInterner;
-    /** add units as optinal*/
+    /** unit of the property */
     units?: string;
 }
 

--- a/src/map/data.ts
+++ b/src/map/data.ts
@@ -57,7 +57,6 @@ export class StringInterner {
 
 /** Transform a property to a numeric property */
 function propertyToNumeric(name: string, property: Property): NumericProperty {
-    //console.log(name, property.units);
     const prop_type = typeof property.values[0];
     if (prop_type === 'number') {
         return {

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -467,7 +467,9 @@ export class PropertiesMap {
                 this._options.color.max.value = max;
 
                 this._relayout(({
-                    'coloraxis.colorbar.title.text': this._options.color.property.value,
+                    'coloraxis.colorbar.title.text': this._title(
+                        this._options.color.property.value
+                    ),
                     'coloraxis.showscale': true,
                 } as unknown) as Layout);
             } else {
@@ -688,7 +690,7 @@ export class PropertiesMap {
         layout.coloraxis.colorscale = this._options.colorScale();
         layout.coloraxis.cmin = this._options.color.min.value;
         layout.coloraxis.cmax = this._options.color.max.value;
-        layout.coloraxis.colorbar.title.text = this._options.color.property.value;
+        layout.coloraxis.colorbar.title.text = this._title(this._options.color.property.value);
         layout.coloraxis.colorbar.len = this._colorbarLen();
 
         // Create an empty plot and fill it below

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -774,16 +774,16 @@ export class PropertiesMap {
         return this._selectTrace<number[]>(values, selected, trace);
     }
 
-    /** Prepare a title of an axis with potential units */
-    private _title(name: string): string{
-        let title = name;
-        let units = this._property(title).units;
-            if (units !== undefined){
-                title += ` [${units}]`;
+    private _title(name: string): string {
+        if (name !== '') {
+            const units = this._property(name).units;
+            if (units !== undefined) {
+                return name + ` [${units}]`;
             }
-        return title;
+        }
+        return name;
     }
-    
+
     /**
      * Get the color values to use with the given plotly `trace`, or all of
      * them if `trace === undefined`

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -684,7 +684,7 @@ export class PropertiesMap {
         layout.yaxis.type = this._options.y.scale.value;
         layout.scene.xaxis.title = this._title(this._options.x.property.value);
         layout.scene.yaxis.title = this._title(this._options.y.property.value);
-        layout.scene.zaxis.title = this._options.z.property.value; // using this._title(this._options.z.property.value) here seems to cause troubles
+        layout.scene.zaxis.title = this._title(this._options.z.property.value);
         layout.coloraxis.colorscale = this._options.colorScale();
         layout.coloraxis.cmin = this._options.color.min.value;
         layout.coloraxis.cmax = this._options.color.max.value;

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -780,7 +780,7 @@ export class PropertiesMap {
         if (name !== '') {
             const units = this._property(name).units;
             if (units !== undefined) {
-                return name + ` [${units}]`;
+                return name + `/${units}`;
             }
         }
         return name;

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -342,8 +342,8 @@ export class PropertiesMap {
             const values = this._coordinates(this._options.x) as number[][];
             this._restyle({ x: values }, [0, 1]);
             this._relayout(({
-                'scene.xaxis.title': this._options.x.property.value,
-                'xaxis.title': this._options.x.property.value,
+                'scene.xaxis.title': this._title(this._options.x.property.value),
+                'xaxis.title': this._title(this._options.x.property.value),
             } as unknown) as Layout);
         };
 
@@ -386,8 +386,8 @@ export class PropertiesMap {
             const values = this._coordinates(this._options.y) as number[][];
             this._restyle({ y: values }, [0, 1]);
             this._relayout(({
-                'scene.yaxis.title': this._options.y.property.value,
-                'yaxis.title': this._options.y.property.value,
+                'scene.yaxis.title': this._title(this._options.y.property.value),
+                'yaxis.title': this._title(this._options.y.property.value),
             } as unknown) as Layout);
         };
 
@@ -421,7 +421,7 @@ export class PropertiesMap {
             const values = this._coordinates(this._options.z);
             this._restyle({ z: values } as Data, [0, 1]);
             this._relayout(({
-                'scene.zaxis.title': this._options.z.property.value,
+                'scene.zaxis.title': this._title(this._options.z.property.value),
             } as unknown) as Layout);
         };
 
@@ -678,13 +678,13 @@ export class PropertiesMap {
         // make a copy of the default layout
         const layout = JSON.parse(JSON.stringify(DEFAULT_LAYOUT)) as typeof DEFAULT_LAYOUT;
         // and set values speific to the displayed dataset
-        layout.xaxis.title = this._options.x.property.value;
-        layout.yaxis.title = this._options.y.property.value;
+        layout.xaxis.title = this._title(this._options.x.property.value);
+        layout.yaxis.title = this._title(this._options.y.property.value);
         layout.xaxis.type = this._options.x.scale.value;
         layout.yaxis.type = this._options.y.scale.value;
-        layout.scene.xaxis.title = this._options.x.property.value;
-        layout.scene.yaxis.title = this._options.y.property.value;
-        layout.scene.zaxis.title = this._options.z.property.value;
+        layout.scene.xaxis.title = this._title(this._options.x.property.value);
+        layout.scene.yaxis.title = this._title(this._options.y.property.value);
+        layout.scene.zaxis.title = this._options.z.property.value; // using this._title(this._options.z.property.value) here seems to cause troubles
         layout.coloraxis.colorscale = this._options.colorScale();
         layout.coloraxis.cmin = this._options.color.min.value;
         layout.coloraxis.cmax = this._options.color.max.value;
@@ -774,6 +774,16 @@ export class PropertiesMap {
         return this._selectTrace<number[]>(values, selected, trace);
     }
 
+    /** Prepare a title of an axis with potential units */
+    private _title(name: string): string{
+        let title = name;
+        let units = this._property(title).units;
+            if (units !== undefined){
+                title += ` [${units}]`;
+            }
+        return title;
+    }
+    
     /**
      * Get the color values to use with the given plotly `trace`, or all of
      * them if `trace === undefined`


### PR DESCRIPTION
fix #20, allow adding units and description (optional) to properties and show them in the map and the info table 