### PR TITLE
Update options.ts, RE: Issue #109

### DIFF
--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,6 +210,9 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
+        if (!rawSizes.every(x => x > 0)) {
+                sendWarning("This property contains negative values, taking the log will discard them.");
+        }
         const logSlider = (value: number) => {
             const min_slider = 1;
             const max_slider = 100;

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,7 +210,7 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
-        if (!rawSizes.every((x) => x > 0)) {
+        if (!rawSizes.every((x: number) => x > 0)) {
                 sendWarning("This property contains negative values, taking the log will discard them.");
         }
         const logSlider = (value: number) => {

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,9 +210,7 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
-        if (!rawSizes.every((x: number) => x > 0)) {
-                sendWarning("This property contains negative values, taking the log will discard them.");
-        }
+
         const logSlider = (value: number) => {
             const min_slider = 1;
             const max_slider = 100;
@@ -246,6 +244,9 @@ export class MapOptions extends OptionsGroup {
                         scaled = 1.0 / scaled;
                         break;
                     case 'log':
+                        if (scaled < 0) {
+                            sendWarning("This property contains negative values, taking the log will discard them.");
+                        }                        
                         scaled = Math.log(scaled);
                         break;
                     case 'sqrt':

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,7 +210,9 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
-        if (!rawSizes.every((x) => {return x > 0;})) {
+        if (!rawSizes.every((x) => {
+            return x > 0;
+        })) {
                 sendWarning("This property contains negative values, taking the log will discard them.");
         }
         const logSlider = (value: number) => {

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,7 +210,7 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
-        if (!rawSizes.every(x => x > 0)) {
+        if (!rawSizes.every((x) => {return x > 0})) {
                 sendWarning("This property contains negative values, taking the log will discard them.");
         }
         const logSlider = (value: number) => {

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,9 +210,7 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
-        if (!rawSizes.every((x) => {
-            return x > 0;
-        })) {
+        if (!rawSizes.every((x) => x > 0)) {
                 sendWarning("This property contains negative values, taking the log will discard them.");
         }
         const logSlider = (value: number) => {

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -210,7 +210,7 @@ export class MapOptions extends OptionsGroup {
      * all of them if `trace === undefined`.
      */
     public calculateSizes(rawSizes: number[]): number[] {
-        if (!rawSizes.every((x) => {return x > 0})) {
+        if (!rawSizes.every((x) => {return x > 0;})) {
                 sendWarning("This property contains negative values, taking the log will discard them.");
         }
         const logSlider = (value: number) => {


### PR DESCRIPTION
Added a check that all values are positive before applying the operation in the `'log'` case. It will issue a warning for when the log scale is used for negative values.