### PR TITLE
Check that we are not removing the last viewer earlier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2018,7 +2018,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3815,8 +3814,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5822,7 +5820,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -7237,9 +7234,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -13231,7 +13225,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -261,14 +261,13 @@ export class ViewersGrid {
     }
 
     /**
-     * Removes the viewer wiith the given `guid` from the viewer grid.
+     * Removes the viewer with the given `guid` from the viewer grid.
      *
      * @param guid GUID of the viewer to remove
      */
     public removeViewer(guid: GUID): void {
-        if (this._viewers.size === 1) {
-            sendWarning('can not remove the last viewer from the grid');
-        }
+        // don't remove the last viewer
+        assert(this._viewers.size > 1);
 
         // If we removed the active marker, change the active one
         if (this._active === guid) {
@@ -566,6 +565,11 @@ the object was ${JSON.stringify(s)}`
                 </button>`;
             const remove = template.content.firstChild as HTMLElement;
             remove.onclick = () => {
+                if (this._viewers.size === 1) {
+                    sendWarning('can not remove the last viewer from the grid');
+                    return;
+                }
+
                 this.onremove(cellGUID);
                 this.removeViewer(cellGUID);
                 this._setupGrid(this._viewers.size);


### PR DESCRIPTION
Previously, we would send the warning and then proceed to remove data associated with the viewer, leading to strange crashes.

Fix #107 