### PR TITLE
Improving the Map Settings (max/min, step interval, width)

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -144,9 +144,18 @@ export class ChemiscopeApp {
 
         this.visualizer.map.positionSettingsModal = (rect) => {
             const mapRect = getByID('chemiscope-map').getBoundingClientRect();
+
+            let left;
+            if (window.innerWidth < 1400) {
+                // clip modal to the right if it overflows
+                left = window.innerWidth - rect.width - 10;
+            } else {
+                left = mapRect.left + mapRect.width + 25;
+            }
+
             return {
                 top: mapRect.top,
-                left: mapRect.left + mapRect.width + 25,
+                left: left,
             };
         };
 

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -421,6 +421,7 @@ export class PropertiesMap {
                     'xaxis.autorange': true,
                 } as unknown as Layout);
             }
+            this._options.setScaleStep(this._options.x, 'x');
         };
 
         this._options.x.scale.onchange = () => {
@@ -481,6 +482,7 @@ export class PropertiesMap {
                     'yaxis.autorange': true,
                 } as unknown as Layout);
             }
+            this._options.setScaleStep(this._options.y, 'y');
         };
 
         this._options.y.scale.onchange = () => {
@@ -527,6 +529,7 @@ export class PropertiesMap {
                 'scene.zaxis.title': this._title(this._options.z.property.value),
                 'scene.zaxis.autorange': true,
             } as unknown as Layout);
+            this._options.setScaleStep(this._options.z, 'z');
         };
 
         this._options.z.scale.onchange = () => {

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 
-import Plotly, { Axis } from './plotly/plotly-scatter';
+import Plotly from './plotly/plotly-scatter';
 import { Config, Data, Layout, PlotlyScatterElement } from './plotly/plotly-scatter';
 
 import { Property } from '../dataset';
@@ -1143,10 +1143,10 @@ export class PropertiesMap {
         if (bounds.z !== undefined) {
             this._options.z.min.value = bounds.z[0];
             this._options.z.max.value = bounds.z[1];
+        }
 
-            if (!this._is3D()) {
-                this._updateMarkers();
-            }
+        if (!this._is3D()) {
+            this._updateMarkers();
         }
     }
     /**

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1101,6 +1101,7 @@ export class PropertiesMap {
         console.log(this._options.y.max.value);
         console.log(this._options.z);
         console.log(this._options.z.max.value);
+        console.log();
     }
 
     /** Switch current plot from 3D back to 2D */

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1255,6 +1255,7 @@ export class PropertiesMap {
     /** Changes the step of the arrow buttons in min/max input based on dataset range*/
     private setScaleStep(axisBounds: number[], axisName: string): void {
         if (axisBounds !== undefined) {
+            // round to 10 decimal places so it does not break in Firefox
             const step = Math.round(((axisBounds[1] - axisBounds[0]) / 20) * 10 ** 10) / 10 ** 10;
             const minElement = getByID<HTMLInputElement>(`chsp-${axisName}-min`);
             const maxElement = getByID<HTMLInputElement>(`chsp-${axisName}-max`);

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -421,9 +421,7 @@ export class PropertiesMap {
                     'xaxis.autorange': true,
                 } as unknown as Layout);
             }
-            console.log('---change of x property---');
-            console.log(this._options.x);
-            this._options.setScaleStep(this._options.x, 'x');
+            this.setScaleStep(this._getBounds().x, 'x');
         };
 
         this._options.x.scale.onchange = () => {
@@ -484,7 +482,7 @@ export class PropertiesMap {
                     'yaxis.autorange': true,
                 } as unknown as Layout);
             }
-            this._options.setScaleStep(this._options.y, 'y');
+            this.setScaleStep(this._getBounds().y, 'y');
         };
 
         this._options.y.scale.onchange = () => {
@@ -531,8 +529,9 @@ export class PropertiesMap {
                 'scene.zaxis.title': this._title(this._options.z.property.value),
                 'scene.zaxis.autorange': true,
             } as unknown as Layout);
-            console.log('---z property change---');
-            this._options.setScaleStep(this._options.z, 'z');
+            if (this._getBounds().z !== undefined) {
+                this.setScaleStep(this._getBounds().z as number[], 'z');
+            }
         };
 
         this._options.z.scale.onchange = () => {
@@ -852,10 +851,11 @@ export class PropertiesMap {
         this._plot.on('plotly_afterplot', () => this._afterplot());
         this._updateMarkers();
 
-        this.setScaleStep(this._options.x, 'x');
-        this.setScaleStep(this._options.y, 'y');
-        if (this._options.z.property !== undefined) {
-            this.setScaleStep(this._options.z, 'z');
+        const bounds = this._getBounds();
+        this.setScaleStep(bounds.x, 'x');
+        this.setScaleStep(bounds.y, 'y');
+        if (bounds.z !== undefined) {
+            this.setScaleStep(bounds.z, 'z');
         }
     }
 
@@ -1096,12 +1096,6 @@ export class PropertiesMap {
             'scene.yaxis.type': this._options.y.scale.value as Plotly.AxisType,
             'scene.zaxis.type': this._options.z.scale.value as Plotly.AxisType,
         } as unknown as Layout);
-        console.log('inside 3D switch');
-        console.log(this._options.y);
-        console.log(this._options.y.max.value);
-        console.log(this._options.z);
-        console.log(this._options.z.max.value);
-        console.log();
     }
 
     /** Switch current plot from 3D back to 2D */
@@ -1258,14 +1252,14 @@ export class PropertiesMap {
     }
 
     /** Changes the step of the arrow buttons in min/max input based on dataset range*/
-    private setScaleStep(axis: AxisOptions, axisName: string): void {
-        const step = ((axis.max.value - axis.min.value) / 20) as number;
-        const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
-        const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
-        minElement.step = `${step}`;
-        maxElement.step = `${step}`;
-        console.log(axis.max.value, axis.min.value);
-        console.log(minElement, maxElement, step);
+    private setScaleStep(axisBounds: number[], axisName: string): void {
+        if (axisBounds !== undefined) {
+            const step = ((axisBounds[1] - axisBounds[0]) / 20) as number;
+            const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
+            const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
+            minElement.step = `${step}`;
+            maxElement.step = `${step}`;
+        }
     }
 }
 

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1132,13 +1132,30 @@ export class PropertiesMap {
     private _afterplot(): void {
         const bounds = this._getBounds();
 
-        this._options.x.min.value = bounds.x[0];
-        this._options.x.max.value = bounds.x[1];
-        this._options.y.min.value = bounds.y[0];
-        this._options.y.max.value = bounds.y[1];
+        if (this._options.x.scale.value === 'log') {
+            this._options.x.min.value = 10 ** bounds.x[0];
+            this._options.x.max.value = 10 ** bounds.x[1];
+        } else {
+            this._options.x.min.value = bounds.x[0];
+            this._options.x.max.value = bounds.x[1];
+        }
+
+        if (this._options.y.scale.value === 'log') {
+            this._options.y.min.value = 10 ** bounds.x[0];
+            this._options.y.max.value = 10 ** bounds.x[1];
+        } else {
+            this._options.y.min.value = bounds.x[0];
+            this._options.y.max.value = bounds.x[1];
+        }
+
         if (bounds.z !== undefined) {
-            this._options.z.min.value = bounds.z[0];
-            this._options.z.max.value = bounds.z[1];
+            if (this._options.z.scale.value === 'log') {
+                this._options.z.min.value = 10 ** bounds.z[0];
+                this._options.z.max.value = 10 ** bounds.z[1];
+            } else {
+                this._options.z.min.value = bounds.z[0];
+                this._options.z.max.value = bounds.z[1];
+            }
         }
 
         if (!this._is3D()) {

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 
-import Plotly from './plotly/plotly-scatter';
+import Plotly, { Axis } from './plotly/plotly-scatter';
 import { Config, Data, Layout, PlotlyScatterElement } from './plotly/plotly-scatter';
 
 import { Property } from '../dataset';
@@ -425,6 +425,7 @@ export class PropertiesMap {
 
         this._options.x.scale.onchange = () => {
             negativeLogWarning(this._options.x);
+            this._options.logLinearLabelSwitch(this._options.x, 'x');
             if (this._is3D()) {
                 this._relayout({
                     'scene.xaxis.type': this._options.x.scale.value,
@@ -484,6 +485,7 @@ export class PropertiesMap {
 
         this._options.y.scale.onchange = () => {
             negativeLogWarning(this._options.y);
+            this._options.logLinearLabelSwitch(this._options.y, 'y');
             if (this._is3D()) {
                 this._relayout({
                     'scene.yaxis.type': this._options.y.scale.value,
@@ -529,6 +531,7 @@ export class PropertiesMap {
 
         this._options.z.scale.onchange = () => {
             negativeLogWarning(this._options.z);
+            this._options.logLinearLabelSwitch(this._options.z, 'z');
             if (this._options.z.property.value !== '') {
                 this._relayout({
                     'scene.zaxis.type': this._options.z.scale.value,

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1132,37 +1132,20 @@ export class PropertiesMap {
     private _afterplot(): void {
         const bounds = this._getBounds();
 
-        if (this._options.x.scale.value === 'log') {
-            this._options.x.min.value = 10 ** bounds.x[0];
-            this._options.x.max.value = 10 ** bounds.x[1];
-        } else {
-            this._options.x.min.value = bounds.x[0];
-            this._options.x.max.value = bounds.x[1];
-        }
-
-        if (this._options.y.scale.value === 'log') {
-            this._options.y.min.value = 10 ** bounds.x[0];
-            this._options.y.max.value = 10 ** bounds.x[1];
-        } else {
-            this._options.y.min.value = bounds.x[0];
-            this._options.y.max.value = bounds.x[1];
-        }
+        this._options.x.min.value = bounds.x[0];
+        this._options.x.max.value = bounds.x[1];
+        this._options.y.min.value = bounds.y[0];
+        this._options.y.max.value = bounds.y[1];
 
         if (bounds.z !== undefined) {
-            if (this._options.z.scale.value === 'log') {
-                this._options.z.min.value = 10 ** bounds.z[0];
-                this._options.z.max.value = 10 ** bounds.z[1];
-            } else {
-                this._options.z.min.value = bounds.z[0];
-                this._options.z.max.value = bounds.z[1];
+            this._options.z.min.value = bounds.z[0];
+            this._options.z.max.value = bounds.z[1];
+
+            if (!this._is3D()) {
+                this._updateMarkers();
             }
         }
-
-        if (!this._is3D()) {
-            this._updateMarkers();
-        }
     }
-
     /**
      * Update the position, color & size of markers within the data array
      */

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1139,7 +1139,6 @@ export class PropertiesMap {
         this._options.x.max.value = bounds.x[1];
         this._options.y.min.value = bounds.y[0];
         this._options.y.max.value = bounds.y[1];
-
         if (bounds.z !== undefined) {
             this._options.z.min.value = bounds.z[0];
             this._options.z.max.value = bounds.z[1];
@@ -1149,6 +1148,7 @@ export class PropertiesMap {
             this._updateMarkers();
         }
     }
+
     /**
      * Update the position, color & size of markers within the data array
      */

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1254,7 +1254,7 @@ export class PropertiesMap {
     /** Changes the step of the arrow buttons in min/max input based on dataset range*/
     private setScaleStep(axisBounds: number[], axisName: string): void {
         if (axisBounds !== undefined) {
-            const step = ((axisBounds[1] - axisBounds[0]) / 20) as number;
+            const step = (axisBounds[1] - axisBounds[0]) / 20;
             const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
             const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
             minElement.step = `${step}`;

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1254,7 +1254,7 @@ export class PropertiesMap {
     /** Changes the step of the arrow buttons in min/max input based on dataset range*/
     private setScaleStep(axisBounds: number[], axisName: string): void {
         if (axisBounds !== undefined) {
-            const step = (axisBounds[1] - axisBounds[0]) / 20;
+            const step = Math.round(((axisBounds[1] - axisBounds[0]) / 20) * 10 ** 10) / 10 ** 10;
             const minElement = getByID<HTMLInputElement>(`chsp-${axisName}-min`);
             const maxElement = getByID<HTMLInputElement>(`chsp-${axisName}-max`);
             minElement.step = `${step}`;

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -421,6 +421,8 @@ export class PropertiesMap {
                     'xaxis.autorange': true,
                 } as unknown as Layout);
             }
+            console.log('---change of x property---');
+            console.log(this._options.x);
             this._options.setScaleStep(this._options.x, 'x');
         };
 
@@ -529,6 +531,7 @@ export class PropertiesMap {
                 'scene.zaxis.title': this._title(this._options.z.property.value),
                 'scene.zaxis.autorange': true,
             } as unknown as Layout);
+            console.log('---z property change---');
             this._options.setScaleStep(this._options.z, 'z');
         };
 
@@ -1093,6 +1096,11 @@ export class PropertiesMap {
             'scene.yaxis.type': this._options.y.scale.value as Plotly.AxisType,
             'scene.zaxis.type': this._options.z.scale.value as Plotly.AxisType,
         } as unknown as Layout);
+        console.log('inside 3D switch');
+        console.log(this._options.y);
+        console.log(this._options.y.max.value);
+        console.log(this._options.z);
+        console.log(this._options.z.max.value);
     }
 
     /** Switch current plot from 3D back to 2D */

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -529,7 +529,7 @@ export class PropertiesMap {
                 'scene.zaxis.title': this._title(this._options.z.property.value),
                 'scene.zaxis.autorange': true,
             } as unknown as Layout);
-            if (this._getBounds().z !== undefined) {
+            if (this._is3D()) {
                 this.setScaleStep(this._getBounds().z as number[], 'z');
             }
         };

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1255,8 +1255,8 @@ export class PropertiesMap {
     private setScaleStep(axisBounds: number[], axisName: string): void {
         if (axisBounds !== undefined) {
             const step = (axisBounds[1] - axisBounds[0]) / 20;
-            const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
-            const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
+            const minElement = getByID<HTMLInputElement>(`chsp-${axisName}-min`);
+            const maxElement = getByID<HTMLInputElement>(`chsp-${axisName}-max`);
             minElement.step = `${step}`;
             maxElement.step = `${step}`;
         }

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -425,7 +425,7 @@ export class PropertiesMap {
 
         this._options.x.scale.onchange = () => {
             negativeLogWarning(this._options.x);
-            this._options.logLinearLabelSwitch(this._options.x, 'x');
+            this._options.setLogLabel(this._options.x, 'x');
             if (this._is3D()) {
                 this._relayout({
                     'scene.xaxis.type': this._options.x.scale.value,
@@ -485,7 +485,7 @@ export class PropertiesMap {
 
         this._options.y.scale.onchange = () => {
             negativeLogWarning(this._options.y);
-            this._options.logLinearLabelSwitch(this._options.y, 'y');
+            this._options.setLogLabel(this._options.y, 'y');
             if (this._is3D()) {
                 this._relayout({
                     'scene.yaxis.type': this._options.y.scale.value,
@@ -531,7 +531,7 @@ export class PropertiesMap {
 
         this._options.z.scale.onchange = () => {
             negativeLogWarning(this._options.z);
-            this._options.logLinearLabelSwitch(this._options.z, 'z');
+            this._options.setLogLabel(this._options.z, 'z');
             if (this._options.z.property.value !== '') {
                 this._relayout({
                     'scene.zaxis.type': this._options.z.scale.value,

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -848,6 +848,12 @@ export class PropertiesMap {
 
         this._plot.on('plotly_afterplot', () => this._afterplot());
         this._updateMarkers();
+
+        this.setScaleStep(this._options.x, 'x');
+        this.setScaleStep(this._options.y, 'y');
+        if (this._options.z.property !== undefined) {
+            this.setScaleStep(this._options.z, 'z');
+        }
     }
 
     /** Get the property with the given name */
@@ -1240,6 +1246,17 @@ export class PropertiesMap {
             inside = inside && isInsideRange(z, bounds.z, tolerance);
         }
         return inside;
+    }
+
+    /** Changes the step of the arrow buttons in min/max input based on dataset range*/
+    private setScaleStep(axis: AxisOptions, axisName: string): void {
+        const step = ((axis.max.value - axis.min.value) / 20) as number;
+        const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
+        const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
+        minElement.step = `${step}`;
+        maxElement.step = `${step}`;
+        console.log(axis.max.value, axis.min.value);
+        console.log(minElement, maxElement, step);
     }
 }
 

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -851,6 +851,7 @@ export class PropertiesMap {
         this._plot.on('plotly_afterplot', () => this._afterplot());
         this._updateMarkers();
 
+        // set step of min/max select arrows based on the plot range
         const bounds = this._getBounds();
         this.setScaleStep(bounds.x, 'x');
         this.setScaleStep(bounds.y, 'y');

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -1,5 +1,5 @@
 <div id="chsp-settings" class="modal fade" tabindex="-1">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header chsp-modal-header">
                 <h4 class="modal-title">Map settings</h4>
@@ -163,6 +163,8 @@
                     </button>
 
                     <div class="collapse chsp-map-extra-options" id="chsp-extra-color">
+                        <button class="btn btn-sm btn-light" type="button" id="chsp-color-reset">reset</button>
+
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
                                 <label class="input-group-text" for="chsp-color-min">min:</label>
@@ -176,8 +178,6 @@
                             </div>
                             <input id="chsp-color-max" class="form-control" type="number" step="any" />
                         </div>
-
-                        <button class="btn btn-sm btn-light" type="button" id="chsp-color-reset">reset</button>
                     </div>
 
                     <div class="input-group input-group-sm">

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -163,7 +163,7 @@
                     </button>
 
                     <div class="collapse chsp-map-extra-options" id="chsp-extra-color">
-                        <button class="btn btn-sm btn-light" type="button" id="chsp-color-reset">reset</button>
+                        <button class="btn btn-sm btn-light" type="button" id="chsp-color-reset" style="width: 100%">reset</button>
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -133,7 +133,7 @@
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label id="chsp-z-max-label" class="input-group-text" for="chsp-x-max">max:</label>
+                                <label id="chsp-z-max-label" class="input-group-text" for="chsp-z-max">max:</label>
                             </div>
                             <input id="chsp-z-max" class="form-control" type="number" step="any" disabled />
                         </div>

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -38,14 +38,14 @@
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="chsp-x-min">min:</label>
+                                <label id="chsp-x-min-label" class="input-group-text" for="chsp-x-min">min:</label>
                             </div>
                             <input id="chsp-x-min" class="form-control" type="number" step="any" />
                         </div>
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="chsp-x-max">max:</label>
+                                <label id="chsp-x-max-label" class="input-group-text" for="chsp-x-max">max:</label>
                             </div>
                             <input id="chsp-x-max" class="form-control" type="number" step="any" />
                         </div>
@@ -81,14 +81,14 @@
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="chsp-y-min">min:</label>
+                                <label id="chsp-y-min-label" class="input-group-text" for="chsp-y-min">min:</label>
                             </div>
                             <input id="chsp-y-min" class="form-control" type="number" step="any" />
                         </div>
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="chsp-y-max">max:</label>
+                                <label id="chsp-y-max-label" class="input-group-text" for="chsp-y-max">max:</label>
                             </div>
                             <input id="chsp-y-max" class="form-control" type="number" step="any" />
                         </div>
@@ -126,14 +126,14 @@
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="chsp-z-min">min:</label>
+                                <label id="chsp-z-min-label" class="input-group-text" for="chsp-z-min">min:</label>
                             </div>
                             <input id="chsp-z-min" class="form-control" type="number" step="any" disabled />
                         </div>
 
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
-                                <label class="input-group-text" for="chsp-x-max">max:</label>
+                                <label id="chsp-z-max-label" class="input-group-text" for="chsp-x-max">max:</label>
                             </div>
                             <input id="chsp-z-max" class="form-control" type="number" step="any" disabled />
                         </div>

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -40,7 +40,7 @@
                             <div class="input-group-prepend">
                                 <label class="input-group-text" for="chsp-x-min">min:</label>
                             </div>
-                            <input id="chsp-x-min" class="form-control" type="number" step="any" />
+                            <input id="chsp-x-min" class="form-control" type="string" step="any" />
                         </div>
 
                         <div class="input-group input-group-sm">

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -40,7 +40,7 @@
                             <div class="input-group-prepend">
                                 <label class="input-group-text" for="chsp-x-min">min:</label>
                             </div>
-                            <input id="chsp-x-min" class="form-control" type="string" step="any" />
+                            <input id="chsp-x-min" class="form-control" type="number" step="any" />
                         </div>
 
                         <div class="input-group input-group-sm">

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -437,7 +437,7 @@ export class MapOptions extends OptionsGroup {
 
     /** Changes the step of the arrow buttons in min/max input based on dataset range*/
     public setScaleStep(axis: AxisOptions, axisName: string): void {
-        const step = ((axis.max.value - axis.min.value) / 20) as number;
+        const step = (axis.max.value - axis.min.value) / 20;
         const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
         const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
         minElement.step = `${step}`;

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -318,10 +318,6 @@ export class MapOptions extends OptionsGroup {
                 // display: block to ensure modalDialog.offsetWidth is non-zero
                 (modalDialog.parentNode as HTMLElement).style.display = 'block';
 
-                const { top, left } = this._positionSettingsModal(
-                    modalDialog.getBoundingClientRect()
-                );
-
                 // set width first, since setting position can influence it
                 // scale width of the larger modal-lg class
                 modalDialog.style.width = `${modalDialog.offsetWidth / 1.5}px`;
@@ -330,13 +326,13 @@ export class MapOptions extends OptionsGroup {
                 // unset margins when using position: fixed
                 modalDialog.style.margin = '0';
                 modalDialog.style.position = 'fixed';
-                modalDialog.style.top = `${top}px`;
 
-                if (window.innerWidth < 1400) {
-                    modalDialog.style.right = `10px`;
-                } else {
-                    modalDialog.style.left = `${left}px`;
-                }
+                const { top, left } = this._positionSettingsModal(
+                    modalDialog.getBoundingClientRect()
+                );
+
+                modalDialog.style.top = `${top}px`;
+                modalDialog.style.left = `${left}px`;
             }
         });
 

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -344,10 +344,13 @@ export class MapOptions extends OptionsGroup {
             selectXProperty.options.add(new Option(key, key));
         }
         this.x.property.bind(selectXProperty, 'value');
-        this.x.min.bind('chsp-x-min', 'value');
-        this.x.max.bind('chsp-x-max', 'value');
         this.x.scale.bind('chsp-x-scale', 'value');
 
+        if (this.x.scale.value === 'log') {
+        } else {
+            this.x.min.bind('chsp-x-min', 'value');
+            this.x.max.bind('chsp-x-max', 'value');
+        }
         // ======= data used as y values
         const selectYProperty = getByID<HTMLSelectElement>('chsp-y');
         selectYProperty.options.length = 0;

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -423,11 +423,10 @@ export class MapOptions extends OptionsGroup {
 
     /** Changes the min/max range label between linear and log appropriately */
     public setLogLabel(axis: AxisOptions, axisName: string): void {
-        const optionsContainer = getByID(`chsp-extra-${axisName}`);
-        const minInputLabel = optionsContainer.getElementsByClassName('input-group-text')[1];
-        const maxInputLabel = optionsContainer.getElementsByClassName('input-group-text')[2];
+        const minInputLabel = getByID(`chsp-${axisName}-min-label`);
+        const maxInputLabel = getByID(`chsp-${axisName}-max-label`);
 
-        if (this.x.scale.value === 'log') {
+        if (axis.scale.value === 'log') {
             minInputLabel.innerHTML = 'min: 10^';
             maxInputLabel.innerHTML = 'max: 10^';
         } else {

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -323,14 +323,17 @@ export class MapOptions extends OptionsGroup {
                 );
 
                 // set width first, since setting position can influence it
+                // scale width of the larger modal-lg class
                 modalDialog.style.width = `${modalDialog.offsetWidth / 1.5}px`;
+                // minimum width so that text in rows remains on a single line
+                modalDialog.style.minWidth = `400px`;
                 // unset margins when using position: fixed
                 modalDialog.style.margin = '0';
                 modalDialog.style.position = 'fixed';
                 modalDialog.style.top = `${top}px`;
 
-                if (screen.width < 1400) {
-                    modalDialog.style.left = `${left / 2}px`;
+                if (window.innerWidth < 1400) {
+                    modalDialog.style.right = `10px`;
                 } else {
                     modalDialog.style.left = `${left}px`;
                 }

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -153,10 +153,6 @@ export class MapOptions extends OptionsGroup {
 
         this._bind(properties);
         this.applySettings(settings);
-
-        this.setScaleStep(this.x, 'x');
-        this.setScaleStep(this.y, 'y');
-        this.setScaleStep(this.z, 'z');
     }
 
     /**

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -339,18 +339,18 @@ export class MapOptions extends OptionsGroup {
     private _bind(properties: NumericProperties): void {
         // ======= data used as x values
         const selectXProperty = getByID<HTMLSelectElement>('chsp-x');
+
         selectXProperty.options.length = 0;
         for (const key in properties) {
             selectXProperty.options.add(new Option(key, key));
         }
+
         this.x.property.bind(selectXProperty, 'value');
         this.x.scale.bind('chsp-x-scale', 'value');
 
-        if (this.x.scale.value === 'log') {
-        } else {
-            this.x.min.bind('chsp-x-min', 'value');
-            this.x.max.bind('chsp-x-max', 'value');
-        }
+        this.x.min.bind('chsp-x-min', 'value');
+        this.x.max.bind('chsp-x-max', 'value');
+
         // ======= data used as y values
         const selectYProperty = getByID<HTMLSelectElement>('chsp-y');
         selectYProperty.options.length = 0;
@@ -423,4 +423,18 @@ export class MapOptions extends OptionsGroup {
     public colorScale(): Plotly.ColorScale {
         return COLOR_MAPS[this.palette.value];
     }
+
+    public logLinearLabelSwitch = (axis: AxisOptions, axisName: string) => {
+        const optionsContainer = getByID<HTMLElement>(`chsp-extra-${axisName}`);
+        const minInputLabel = optionsContainer.getElementsByClassName('input-group-text')[1];
+        const maxInputLabel = optionsContainer.getElementsByClassName('input-group-text')[2];
+
+        if (this.x.scale.value === 'log') {
+            minInputLabel.innerHTML = 'min: 10^';
+            maxInputLabel.innerHTML = 'max: 10^';
+        } else {
+            minInputLabel.innerHTML = 'min:';
+            maxInputLabel.innerHTML = 'max:';
+        }
+    };
 }

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -421,7 +421,7 @@ export class MapOptions extends OptionsGroup {
         return COLOR_MAPS[this.palette.value];
     }
 
-    public logLinearLabelSwitch = (axis: AxisOptions, axisName: string) => {
+    public logLinearLabelSwitch(axis: AxisOptions, axisName: string): void {
         const optionsContainer = getByID<HTMLElement>(`chsp-extra-${axisName}`);
         const minInputLabel = optionsContainer.getElementsByClassName('input-group-text')[1];
         const maxInputLabel = optionsContainer.getElementsByClassName('input-group-text')[2];

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -434,15 +434,4 @@ export class MapOptions extends OptionsGroup {
             maxInputLabel.innerHTML = 'max:';
         }
     }
-
-    /** Changes the step of the arrow buttons in min/max input based on dataset range*/
-    public setScaleStep(axis: AxisOptions, axisName: string): void {
-        const step = (axis.max.value - axis.min.value) / 20;
-        const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
-        const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
-        minElement.step = `${step}`;
-        maxElement.step = `${step}`;
-        console.log(axis.max.value, axis.min.value);
-        console.log(minElement, maxElement, step);
-    }
 }

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -323,12 +323,17 @@ export class MapOptions extends OptionsGroup {
                 );
 
                 // set width first, since setting position can influence it
-                modalDialog.style.width = '35%'; //`${modalDialog.offsetWidth / 1.2}px`;
+                modalDialog.style.width = `${modalDialog.offsetWidth / 1.5}px`;
                 // unset margins when using position: fixed
                 modalDialog.style.margin = '0';
                 modalDialog.style.position = 'fixed';
                 modalDialog.style.top = `${top}px`;
-                modalDialog.style.left = `${left}px`;
+
+                if (screen.width < 1400) {
+                    modalDialog.style.left = `${left / 2}px`;
+                } else {
+                    modalDialog.style.left = `${left}px`;
+                }
             }
         });
 

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -423,7 +423,7 @@ export class MapOptions extends OptionsGroup {
 
     /** Changes the min/max range label between linear and log appropriately */
     public setLogLabel(axis: AxisOptions, axisName: string): void {
-        const optionsContainer = getByID<HTMLElement>(`chsp-extra-${axisName}`);
+        const optionsContainer = getByID(`chsp-extra-${axisName}`);
         const minInputLabel = optionsContainer.getElementsByClassName('input-group-text')[1];
         const maxInputLabel = optionsContainer.getElementsByClassName('input-group-text')[2];
 

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -346,10 +346,9 @@ export class MapOptions extends OptionsGroup {
         }
 
         this.x.property.bind(selectXProperty, 'value');
-        this.x.scale.bind('chsp-x-scale', 'value');
-
         this.x.min.bind('chsp-x-min', 'value');
         this.x.max.bind('chsp-x-max', 'value');
+        this.x.scale.bind('chsp-x-scale', 'value');
 
         // ======= data used as y values
         const selectYProperty = getByID<HTMLSelectElement>('chsp-y');

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -421,7 +421,8 @@ export class MapOptions extends OptionsGroup {
         return COLOR_MAPS[this.palette.value];
     }
 
-    public logLinearLabelSwitch(axis: AxisOptions, axisName: string): void {
+    /** Changes the min/max range label between linear and log appropriately */
+    public setLogLabel(axis: AxisOptions, axisName: string): void {
         const optionsContainer = getByID<HTMLElement>(`chsp-extra-${axisName}`);
         const minInputLabel = optionsContainer.getElementsByClassName('input-group-text')[1];
         const maxInputLabel = optionsContainer.getElementsByClassName('input-group-text')[2];
@@ -433,5 +434,5 @@ export class MapOptions extends OptionsGroup {
             minInputLabel.innerHTML = 'min:';
             maxInputLabel.innerHTML = 'max:';
         }
-    };
+    }
 }

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -339,12 +339,10 @@ export class MapOptions extends OptionsGroup {
     private _bind(properties: NumericProperties): void {
         // ======= data used as x values
         const selectXProperty = getByID<HTMLSelectElement>('chsp-x');
-
         selectXProperty.options.length = 0;
         for (const key in properties) {
             selectXProperty.options.add(new Option(key, key));
         }
-
         this.x.property.bind(selectXProperty, 'value');
         this.x.min.bind('chsp-x-min', 'value');
         this.x.max.bind('chsp-x-max', 'value');

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -153,6 +153,10 @@ export class MapOptions extends OptionsGroup {
 
         this._bind(properties);
         this.applySettings(settings);
+
+        this.setScaleStep(this.x, 'x');
+        this.setScaleStep(this.y, 'y');
+        this.setScaleStep(this.z, 'z');
     }
 
     /**
@@ -323,7 +327,7 @@ export class MapOptions extends OptionsGroup {
                 );
 
                 // set width first, since setting position can influence it
-                modalDialog.style.width = `${modalDialog.offsetWidth}px`;
+                modalDialog.style.width = '35%'; //`${modalDialog.offsetWidth / 1.2}px`;
                 // unset margins when using position: fixed
                 modalDialog.style.margin = '0';
                 modalDialog.style.position = 'fixed';
@@ -433,5 +437,16 @@ export class MapOptions extends OptionsGroup {
             minInputLabel.innerHTML = 'min:';
             maxInputLabel.innerHTML = 'max:';
         }
+    }
+
+    /** Changes the step of the arrow buttons in min/max input based on dataset range*/
+    public setScaleStep(axis: AxisOptions, axisName: string): void {
+        const step = ((axis.max.value - axis.min.value) / 20) as number;
+        const minElement = getByID(`chsp-${axisName}-min`) as HTMLInputElement;
+        const maxElement = getByID(`chsp-${axisName}-max`) as HTMLInputElement;
+        minElement.step = `${step}`;
+        maxElement.step = `${step}`;
+        console.log(axis.max.value, axis.min.value);
+        console.log(minElement, maxElement, step);
     }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -129,6 +129,8 @@ export class HTMLOption<T extends OptionsType> {
 
     /** Get the value of this setting */
     public get value(): OptionsValue<T> {
+        console.log('inside getter - this', this);
+        console.log('inside getter', this._value);
         return this._value;
     }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -129,8 +129,6 @@ export class HTMLOption<T extends OptionsType> {
 
     /** Get the value of this setting */
     public get value(): OptionsValue<T> {
-        console.log('inside getter - this', this);
-        console.log('inside getter', this._value);
         return this._value;
     }
 

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -32,7 +32,7 @@
 }
 
 .chsp-extra-options-btn {
-    margin: auto;
+    margin-right: auto;
     display: block;
 }
 
@@ -143,7 +143,7 @@
     display: grid;
     align-items: center;
     justify-items: center;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 0.75fr 1fr 1fr;
     grid-gap: 1em;
     margin-bottom: 1.5em;
 }
@@ -158,6 +158,10 @@
 
 .chsp-map-options .form-check-label {
     width: auto;
+}
+
+#chsp-color-reset {
+    width: 100%;
 }
 
 .chsp-modal-header {

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -160,10 +160,6 @@
     width: auto;
 }
 
-#chsp-color-reset {
-    width: 100%;
-}
-
 .chsp-modal-header {
     cursor: grab;
 }

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -32,7 +32,7 @@
 }
 
 .chsp-extra-options-btn {
-    margin-right: auto;
+    margin: auto;
     display: block;
 }
 
@@ -128,7 +128,7 @@
 
 .chsp-map-options {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 0.5fr;
     align-items: center;
     justify-content: center;
     align-content: start;

--- a/tests/map/options.test.ts
+++ b/tests/map/options.test.ts
@@ -36,24 +36,24 @@ describe('MapOptions', () => {
         const root = document.createElement('div');
         const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
 
-        assertScaleLabel(options.x, 'x');
-        assertScaleLabel(options.y, 'y');
-        assertScaleLabel(options.z, 'z');
+        checkScaleLabel(options.x, 'x');
+        checkScaleLabel(options.y, 'y');
+        checkScaleLabel(options.z, 'z');
 
-        function assertScaleLabel(axisOptions: AxisOptions, axisName: string): void {
+        function checkScaleLabel(axisOptions: AxisOptions, axisName: string): void {
             const min = getByID(`chsp-${axisName}-min-label`);
             const max = getByID(`chsp-${axisName}-max-label`);
             const selectElement = getByID<HTMLSelectElement>(`chsp-${axisName}-scale`);
 
             // change from linear (default) to log scale
-            selectElement.selectedIndex = 1;
+            selectElement.value = 'log';
             selectElement.dispatchEvent(new Event('change'));
             options.setLogLabel(axisOptions, axisName);
             assert(min.innerHTML === 'min: 10^');
             assert(max.innerHTML === 'max: 10^');
 
             // change back from log to linear
-            selectElement.selectedIndex = 0;
+            selectElement.value = 'linear';
             selectElement.dispatchEvent(new Event('change'));
             options.setLogLabel(axisOptions, axisName);
             assert(min.innerHTML === 'min:');

--- a/tests/map/options.test.ts
+++ b/tests/map/options.test.ts
@@ -1,4 +1,5 @@
-import { MapOptions } from '../../src/map/options';
+import { MapOptions, AxisOptions } from '../../src/map/options';
+import { getByID } from '../../src/utils';
 
 import { default as setupJSDOM } from '../jsdom';
 import { assert } from 'chai';
@@ -29,5 +30,29 @@ describe('MapOptions', () => {
         options.remove();
         assert(document.body.innerHTML === '');
         assert(root.innerHTML === '');
+    });
+
+    it('scale label switches between linear and log', () => {
+        const root = document.createElement('div');
+        const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
+
+        assertScaleLabel(options.x, 'x');
+        assertScaleLabel(options.y, 'y');
+        assertScaleLabel(options.z, 'z');
+
+        function assertScaleLabel(axisOptions: AxisOptions, axisName: string): void {
+            const min = getByID(`chsp-${axisName}-min-label`);
+            const max = getByID(`chsp-${axisName}-max-label`);
+
+            // change from linear (default) to log scale
+            options.setLogLabel(axisOptions, axisName);
+            assert(min.innerHTML === 'min: 10^');
+            assert(max.innerHTML === 'max: 10^');
+
+            // change back from log to linear
+            options.setLogLabel(axisOptions, axisName);
+            assert(min.innerHTML === 'min:');
+            assert(max.innerHTML === 'max:');
+        }
     });
 });

--- a/tests/map/options.test.ts
+++ b/tests/map/options.test.ts
@@ -45,11 +45,13 @@ describe('MapOptions', () => {
             const max = getByID(`chsp-${axisName}-max-label`);
 
             // change from linear (default) to log scale
+            axisOptions.scale.value = 'log';
             options.setLogLabel(axisOptions, axisName);
             assert(min.innerHTML === 'min: 10^');
             assert(max.innerHTML === 'max: 10^');
 
             // change back from log to linear
+            axisOptions.scale.value = 'linear';
             options.setLogLabel(axisOptions, axisName);
             assert(min.innerHTML === 'min:');
             assert(max.innerHTML === 'max:');

--- a/tests/map/options.test.ts
+++ b/tests/map/options.test.ts
@@ -43,15 +43,18 @@ describe('MapOptions', () => {
         function assertScaleLabel(axisOptions: AxisOptions, axisName: string): void {
             const min = getByID(`chsp-${axisName}-min-label`);
             const max = getByID(`chsp-${axisName}-max-label`);
+            const selectElement = getByID<HTMLSelectElement>(`chsp-${axisName}-scale`);
 
             // change from linear (default) to log scale
-            axisOptions.scale.value = 'log';
+            selectElement.selectedIndex = 1;
+            selectElement.dispatchEvent(new Event('change'));
             options.setLogLabel(axisOptions, axisName);
             assert(min.innerHTML === 'min: 10^');
             assert(max.innerHTML === 'max: 10^');
 
             // change back from log to linear
-            axisOptions.scale.value = 'linear';
+            selectElement.selectedIndex = 0;
+            selectElement.dispatchEvent(new Event('change'));
             options.setLogLabel(axisOptions, axisName);
             assert(min.innerHTML === 'min:');
             assert(max.innerHTML === 'max:');

--- a/tests/map/options.test.ts
+++ b/tests/map/options.test.ts
@@ -32,7 +32,7 @@ describe('MapOptions', () => {
         assert(root.innerHTML === '');
     });
 
-    it('scale label switches between linear and log', () => {
+    it('scale label for min/max switches between linear and log', () => {
         const root = document.createElement('div');
         const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
 


### PR DESCRIPTION
Fixes #124 

I would say that this is only a small enhancement from the current display of the settings. I had a few other suggestions that might improve the look/feel of the axis settings:

1. Increasing the width of the modal to better display longer strings of digits for the min/max range.
2. Adjusting the input step interval (the arrows that increase or decrease the value) based on some 'useful' range of the dataset. At the moment the step interval is always 1, which may be convenient for some datasets but not for others.
3. Allow to change the logarithm basis from 10 to 'e' (natural logarithm) as well. I am not sure if this a feature which would others find useful, but it just came to my mind. This one would take a little bit more work and integration with Plotly axes displaying.

Let me know what you think!
