### PR TITLE
Sending either id of DOM element or the HTML element itself

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -387,7 +387,7 @@ function getMapSettings(settings: Partial<Settings> | undefined): SavedSettings 
     }
 }
 /** Validate HTML element */
-function isHTMLElement(o: any) {
+function isHTMLElement(o: unknown) {
     return o instanceof HTMLElement;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,20 +60,24 @@ export interface Settings {
  * Check if `o` contains all the expected fields to be a [[Config]].
  */
 function validateConfig(o: JsObject) {
+    if (typeof o !== 'object') {
+        throw Error('the configuration must be a JavaScript object');
+    }
+
     if (!('meta' in o && (typeof o.meta === 'string' || isHTMLElement(o.meta)))) {
-        throw Error('missing "meta" key in chemiscope config');
+        throw Error('missing "meta" key in chemiscope configuration');
     }
 
     if (!('map' in o && (typeof o.map === 'string' || isHTMLElement(o.map)))) {
-        throw Error('missing "map" key in chemiscope config');
+        throw Error('missing "map" key in chemiscope configuration');
     }
 
     if (!('info' in o && (typeof o.info === 'string' || isHTMLElement(o.info)))) {
-        throw Error('missing "info" key in chemiscope config');
+        throw Error('missing "info" key in chemiscope configuration');
     }
 
     if (!('structure' in o && (typeof o.structure === 'string' || isHTMLElement(o.structure)))) {
-        throw Error('missing "structure" key in chemiscope config');
+        throw Error('missing "structure" key in chemiscope configuration');
     }
 
     if ('settings' in o) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ class DefaultVisualizer {
             dataset.structures,
             dataset.environments
         );
-        console.log('after setting up the viewers grid');
+
         if (config.loadStructure !== undefined) {
             this.structure.loadStructure = config.loadStructure;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,12 @@ function validateConfig(o: JsObject) {
         throw Error('missing "info" key in chemiscope configuration');
     }
 
-    if (!('structure' in o && (typeof o.structure === 'string' || o.structure instanceof HTMLElement))) {
+    if (
+        !(
+            'structure' in o &&
+            (typeof o.structure === 'string' || o.structure instanceof HTMLElement)
+        )
+    ) {
         throw Error('missing "structure" key in chemiscope configuration');
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -388,13 +388,7 @@ function getMapSettings(settings: Partial<Settings> | undefined): SavedSettings 
 }
 /** Validate HTML element */
 function isHTMLElement(o: any) {
-    return typeof HTMLElement === 'object'
-        ? o instanceof HTMLElement
-        : o &&
-              typeof o === 'object' &&
-              o !== null &&
-              o.nodeType === 1 &&
-              typeof o.nodeName === 'string';
+    return o instanceof HTMLElement;
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,13 @@ require('./static/chemiscope.css');
  */
 export interface Config {
     /** Id of the DOM element to use for the [[MetadataPanel|metadata display]] */
-    meta: string;
+    meta: string | HTMLElement;
     /** Id of the DOM element to use for the [[PropertiesMap|properties map]] */
-    map: string;
+    map: string | HTMLElement;
     /** Id of the DOM element to use for the [[EnvironmentInfo|environment information]] */
-    info: string;
+    info: string | HTMLElement;
     /** Id of the DOM element to use for the [[ViewersGrid|structure viewer]] */
-    structure: string;
+    structure: string | HTMLElement;
     /** Settings for the map & structure viewer */
     settings?: Partial<Settings>;
     /** Custom structure loading callback, used to set [[ViewersGrid.loadStructure]] */
@@ -60,24 +60,20 @@ export interface Settings {
  * Check if `o` contains all the expected fields to be a [[Config]].
  */
 function validateConfig(o: JsObject) {
-    if (typeof o !== 'object') {
-        throw Error('the configuration must be a JavaScript object');
+    if (!('meta' in o && (typeof o.meta === 'string' || isHTMLElement(o.meta)))) {
+        throw Error('missing "meta" key in chemiscope config');
     }
 
-    if (!('meta' in o && typeof o.meta === 'string')) {
-        throw Error('missing "meta" key in chemiscope configuration');
+    if (!('map' in o && (typeof o.map === 'string' || isHTMLElement(o.map)))) {
+        throw Error('missing "map" key in chemiscope config');
     }
 
-    if (!('map' in o && typeof o.map === 'string')) {
-        throw Error('missing "map" key in chemiscope configuration');
+    if (!('info' in o && (typeof o.info === 'string' || isHTMLElement(o.info)))) {
+        throw Error('missing "info" key in chemiscope config');
     }
 
-    if (!('info' in o && typeof o.info === 'string')) {
-        throw Error('missing "info" key in chemiscope configuration');
-    }
-
-    if (!('structure' in o && typeof o.structure === 'string')) {
-        throw Error('missing "structure" key in chemiscope configuration');
+    if (!('structure' in o && (typeof o.structure === 'string' || isHTMLElement(o.structure)))) {
+        throw Error('missing "structure" key in chemiscope config');
     }
 
     if ('settings' in o) {
@@ -188,7 +184,7 @@ class DefaultVisualizer {
             dataset.structures,
             dataset.environments
         );
-
+        console.log('after setting up the viewers grid');
         if (config.loadStructure !== undefined) {
             this.structure.loadStructure = config.loadStructure;
         }
@@ -220,7 +216,7 @@ class DefaultVisualizer {
 
         // map setup
         this.map = new PropertiesMap(
-            { id: config.map, settings: getMapSettings(config.settings) },
+            { element: config.map, settings: getMapSettings(config.settings) },
             this._indexer,
             dataset.properties
         );
@@ -389,6 +385,16 @@ function getMapSettings(settings: Partial<Settings> | undefined): SavedSettings 
     } else {
         return {};
     }
+}
+/** Validate HTML element */
+function isHTMLElement(o: any) {
+    return typeof HTMLElement === 'object'
+        ? o instanceof HTMLElement
+        : o &&
+              typeof o === 'object' &&
+              o !== null &&
+              o.nodeType === 1 &&
+              typeof o.nodeName === 'string';
 }
 
 export {

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 
 import { Property } from '../dataset';
 import { EnvironmentIndexer, Indexes } from '../indexer';
-import { generateGUID, getByID } from '../utils';
+import { generateGUID, getElement } from '../utils';
 
 import { Slider } from './slider';
 import { Table } from './table';
@@ -75,12 +75,7 @@ export class EnvironmentInfo {
         properties: { [name: string]: Property },
         indexer: EnvironmentIndexer
     ) {
-        if (typeof element !== 'string') {
-            assert(element instanceof HTMLElement);
-            this._root = element;
-        } else {
-            this._root = getByID(element);
-        }
+        this._root = getElement(element);
 
         this._indexer = indexer;
         this.onchange = () => {};

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -63,15 +63,24 @@ export class EnvironmentInfo {
 
     /**
      * Create a new [[EnvironmentInfo]] inside the DOM element with given `id`
-     * @param id         HTML id of the DOM element where the sliders and
+     * @param element    HTML id of the DOM element where the sliders and
      *                   tables should live
      * @param properties properties to be displayed
      * @param indexer    [[EnvironmentIndexer]] used to translate indexes from
      *                   environments index to structure/atom indexes
      * @param viewer     [[ViewersGrid]] from which we get the playback delay
      */
-    constructor(id: string, properties: { [name: string]: Property }, indexer: EnvironmentIndexer) {
-        this._root = getByID(id);
+    constructor(
+        element: string | HTMLElement,
+        properties: { [name: string]: Property },
+        indexer: EnvironmentIndexer
+    ) {
+        if (typeof element !== 'string') {
+            this._root = element;
+        } else {
+            this._root = getByID(element);
+        }
+
         this._indexer = indexer;
         this.onchange = () => {};
         this.startStructurePlayback = () => {};

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -63,8 +63,8 @@ export class EnvironmentInfo {
 
     /**
      * Create a new [[EnvironmentInfo]] inside the DOM element with given `id`
-     * @param element    HTML id of the DOM element where the sliders and
-     *                   tables should live
+     * @param element    HTML element or string 'id' of the element where
+     *                   the sliders and tables should live
      * @param properties properties to be displayed
      * @param indexer    [[EnvironmentIndexer]] used to translate indexes from
      *                   environments index to structure/atom indexes

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -210,13 +210,13 @@ export class PropertiesMap {
      * Create a new [[PropertiesMap]] inside the DOM element with the given HTML
      * `id`
      *
-     * @param id         HTML id of the DOM element where the map should live
+     * @param element   HTML element or HTML id of the DOM element where the name should live
      * @param indexer    [[EnvironmentIndexer]] used to translate indexes from
      *                   environments index to structure/atom indexes
      * @param properties properties to be displayed
      */
     constructor(
-        config: { id: string; settings: SavedSettings },
+        config: { element: string | HTMLElement; settings: SavedSettings },
         indexer: EnvironmentIndexer,
         properties: { [name: string]: Property }
     ) {
@@ -225,7 +225,12 @@ export class PropertiesMap {
         this.activeChanged = () => {};
         this._selected = new Map<GUID, MarkerData>();
 
-        this._root = getByID(config.id);
+        if (typeof config.element !== 'string') {
+            this._root = config.element;
+        } else {
+            this._root = getByID(config.element);
+        }
+
         if (this._root.style.position === '') {
             this._root.style.position = 'relative';
         }

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -210,7 +210,8 @@ export class PropertiesMap {
      * Create a new [[PropertiesMap]] inside the DOM element with the given HTML
      * `id`
      *
-     * @param element   HTML element or HTML id of the DOM element where the name should live
+     * @param element   HTML element or string 'id' of the element where
+     *                   the map should live
      * @param indexer    [[EnvironmentIndexer]] used to translate indexes from
      *                   environments index to structure/atom indexes
      * @param properties properties to be displayed
@@ -226,7 +227,7 @@ export class PropertiesMap {
         this._selected = new Map<GUID, MarkerData>();
 
         if (typeof config.element !== 'string') {
-            assert(element instanceof HTMLElement);
+            assert(config.element instanceof HTMLElement);
             this._root = config.element;
         } else {
             this._root = getByID(config.element);

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -13,7 +13,7 @@ import { Property } from '../dataset';
 import { EnvironmentIndexer, Indexes } from '../indexer';
 import { OptionModificationOrigin, SavedSettings } from '../options';
 import { GUID, PositioningCallback, arrayMaxMin, sendWarning } from '../utils';
-import { enumerate, getByID, getFirstKey, getElement } from '../utils';
+import { enumerate, getByID, getElement, getFirstKey } from '../utils';
 
 import { MapData, NumericProperty } from './data';
 import { MarkerData } from './marker';

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -13,7 +13,7 @@ import { Property } from '../dataset';
 import { EnvironmentIndexer, Indexes } from '../indexer';
 import { OptionModificationOrigin, SavedSettings } from '../options';
 import { GUID, PositioningCallback, arrayMaxMin, sendWarning } from '../utils';
-import { enumerate, getByID, getFirstKey } from '../utils';
+import { enumerate, getByID, getFirstKey, getElement } from '../utils';
 
 import { MapData, NumericProperty } from './data';
 import { MarkerData } from './marker';
@@ -226,12 +226,7 @@ export class PropertiesMap {
         this.activeChanged = () => {};
         this._selected = new Map<GUID, MarkerData>();
 
-        if (typeof config.element !== 'string') {
-            assert(config.element instanceof HTMLElement);
-            this._root = config.element;
-        } else {
-            this._root = getByID(config.element);
-        }
+        this._root = getElement(config.element);
 
         if (this._root.style.position === '') {
             this._root.style.position = 'relative';

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -226,6 +226,7 @@ export class PropertiesMap {
         this._selected = new Map<GUID, MarkerData>();
 
         if (typeof config.element !== 'string') {
+            assert(element instanceof HTMLElement);
             this._root = config.element;
         } else {
             this._root = getByID(config.element);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -86,7 +86,7 @@ export class MetadataPanel {
      * Create a new [[MetadataPanel]] inside the HTML element with the given
      * `id`.
      *
-     * @param element HTML element or HTML id of the DOM element where the name should live
+     * @param element HTML element or HTML id of the DOM element where the name of the dataset should be inserted
      * @param metadata dataset metadata
      */
     constructor(element: string | HTMLElement, metadata: Metadata) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -86,17 +86,22 @@ export class MetadataPanel {
      * Create a new [[MetadataPanel]] inside the HTML element with the given
      * `id`.
      *
-     * @param id       HTML id of the DOM element where the name should live
+     * @param element HTML element or HTML id of the DOM element where the name should live
      * @param metadata dataset metadata
      */
-    constructor(id: string, metadata: Metadata) {
+    constructor(element: string | HTMLElement, metadata: Metadata) {
         // sanitize HTML, all the other field will go through markdown
         metadata.name = metadata.name.replace(/</g, '&lt;');
         metadata.name = metadata.name.replace(/>/g, '&gt;');
 
         this._guid = `chsp-${generateGUID()}`;
 
-        this._name = getByID(id);
+        if (typeof element !== 'string') {
+            this._name = element;
+        } else {
+            this._name = getByID(element);
+        }
+
         this._name.innerHTML = generateName(this._guid, metadata.name);
         this._name.classList.add('chsp-meta');
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import markdown from 'markdown-it';
 
 import { Metadata } from './dataset';
-import { generateGUID, getByID } from './utils';
+import { generateGUID, getElement } from './utils';
 
 function generateName(guid: string, name: string): string {
     return `<span data-toggle="modal" data-target="#${guid}">
@@ -96,12 +96,7 @@ export class MetadataPanel {
 
         this._guid = `chsp-${generateGUID()}`;
 
-        if (typeof element !== 'string') {
-            assert(element instanceof HTMLElement);
-            this._name = element;
-        } else {
-            this._name = getByID(element);
-        }
+        this._name = getElement(element);
 
         this._name.innerHTML = generateName(this._guid, metadata.name);
         this._name.classList.add('chsp-meta');

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -9,7 +9,7 @@ import { Environment, JsObject, Structure, UserStructure, checkStructure } from 
 
 import { EnvironmentIndexer, Indexes } from '../indexer';
 import { SavedSettings } from '../options';
-import { GUID, PositioningCallback } from '../utils';
+import { GUID, PositioningCallback, getElement } from '../utils';
 import { enumerate, generateGUID, getByID, getFirstKey, getNextColor, sendWarning } from '../utils';
 
 import { LoadOptions, MoleculeViewer } from './widget';
@@ -182,13 +182,8 @@ export class ViewersGrid {
         this.oncreate = () => {};
         this.activeChanged = () => {};
 
-        let root;
-        if (typeof element !== 'string') {
-            assert(element instanceof HTMLElement);
-            root = element;
-        } else {
-            root = getByID(element);
-        }
+        const root = getElement(element);
+
         this._root = document.createElement('div');
         this._root.id = 'grid-root';
         this._root.className = 'chsp-structure-viewer-grid';

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -518,7 +518,7 @@ export class ViewersGrid {
      */
     private _setupCell(cellGUID: GUID, colNum: number, rowNum: number): string {
         const cellId = `gi-${cellGUID}`;
-        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement;
+        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement | null;
         let color = '';
 
         if (cell === null) {

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -144,7 +144,8 @@ export class ViewersGrid {
      * Create a new [[ViewersGrid]] inside the HTML element with the given
      * `id`
      *
-     * @param element      HTML element or HTML id of the DOM element where the name should live
+     * @param element      HTML element or string 'id' of the element where
+     *                     viewer should live
      * @param indexer      [[EnvironmentIndexer]] used to translate indexes from
      *                     environments index to structure/atom indexes
      * @param structures   list of structure to display
@@ -518,7 +519,7 @@ export class ViewersGrid {
      */
     private _setupCell(cellGUID: GUID, colNum: number, rowNum: number): string {
         const cellId = `gi-${cellGUID}`;
-        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement | null;
+        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement | null;
         let color = '';
 
         if (cell === null) {

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -657,10 +657,7 @@ export class ViewersGrid {
 
             // add a new widget if necessary
             if (!this._viewers.has(cellGUID)) {
-                const widget = new MoleculeViewer(
-                    this._root.querySelector(`#gi-${cellGUID}`) as HTMLElement,
-                    cellGUID
-                );
+                const widget = new MoleculeViewer(getByID<HTMLElement>(`gi-${cellGUID}`), cellGUID);
 
                 widget.onselect = (atom: number) => {
                     if (this._indexer.mode !== 'atom' || this._active !== cellGUID) {

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -658,7 +658,7 @@ export class ViewersGrid {
             // add a new widget if necessary
             if (!this._viewers.has(cellGUID)) {
                 const widget = new MoleculeViewer(
-                    this._root.querySelector(`#gi-${cellGUID}`) as HTMLElement,
+                    getByID<HTMLElement>(`#gi-${cellGUID}`),
                     cellGUID
                 );
 

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -277,8 +277,7 @@ export class ViewersGrid {
         data.widget.remove();
 
         // remove the cell containing the widget
-        // const cell = getByID(`gi-${guid}`, this._root);
-        const cell = this._root.querySelector(`#${guid}`) as HTMLElement;
+        const cell = getByID(`gi-${guid}`, this._root);
         cell.remove();
 
         this._viewers.delete(guid);

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -658,7 +658,7 @@ export class ViewersGrid {
             // add a new widget if necessary
             if (!this._viewers.has(cellGUID)) {
                 const widget = new MoleculeViewer(
-                    getByID<HTMLElement>(`#gi-${cellGUID}`),
+                    this._root.querySelector(`#gi-${cellGUID}`) as HTMLElement,
                     cellGUID
                 );
 

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -356,7 +356,6 @@ export class ViewersGrid {
 
             // change style of the cell border
             const cell = getByID(`gi-${this._active}`, this._root);
-            // const cell = this._root.querySelector(`#${this._active}`) as HTMLElement;
             cell.classList.toggle('chsp-structure-viewer-cell-active', toggle);
         };
 

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -499,7 +499,6 @@ export class ViewersGrid {
         }
 
         data.current = indexes;
-        console.log('after showing in viewer');
     }
 
     /**
@@ -663,7 +662,6 @@ export class ViewersGrid {
                     this._root.querySelector(`#gi-${cellGUID}`) as HTMLElement,
                     cellGUID
                 );
-                console.log('after inititiation of MoleculeViewer');
 
                 widget.onselect = (atom: number) => {
                     if (this._indexer.mode !== 'atom' || this._active !== cellGUID) {
@@ -697,7 +695,6 @@ export class ViewersGrid {
                     widget.positionSettingsModal = this._positionSettingsModal;
                 }
                 newGUID.push(cellGUID);
-                console.log('after pushing (end of new MoleculeViewever)');
             }
         }
 

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -520,7 +520,7 @@ export class ViewersGrid {
      */
     private _setupCell(cellGUID: GUID, colNum: number, rowNum: number): string {
         const cellId = `gi-${cellGUID}`;
-        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement | null;
+        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement;
         let color = '';
 
         if (cell === null) {

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -16,7 +16,6 @@ import { LoadOptions, MoleculeViewer } from './widget';
 
 import CLOSE_SVG from '../static/close.svg';
 import DUPLICATE_SVG from '../static/duplicate.svg';
-import { Z_UNKNOWN } from 'zlib';
 
 const MAX_WIDGETS = 9;
 

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -515,7 +515,7 @@ export class ViewersGrid {
      */
     private _setupCell(cellGUID: GUID, colNum: number, rowNum: number): string {
         const cellId = `gi-${cellGUID}`;
-        let cell = this._root.querySelector(`#${cellId}`);
+        let cell = this._root.querySelector(`#${cellId}`) as HTMLElement;
         let color = '';
 
         if (cell === null) {

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -37,7 +37,6 @@ function createStyleSheet(rules: string[]): CSSStyleSheet {
  * @param structure the structure to convert
  */
 function setup3DmolStructure(model: $3Dmol.GLModel, structure: Structure): void {
-    console.log('setting up 3D mol structure');
     if (structure.cell !== undefined) {
         const cell = structure.cell;
         // prettier-ignore
@@ -419,7 +418,6 @@ export class MoleculeViewer {
      */
     public applySettings(settings: SavedSettings): void {
         this._options.applySettings(settings);
-        console.log('after apply settings');
     }
 
     /**

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -9,7 +9,7 @@ import { default as $3Dmol } from './3dmol';
 import { assignBonds } from './3dmol/assignBonds';
 
 import { SavedSettings } from '../options';
-import { generateGUID, getByID, unreachable, getElement } from '../utils';
+import { generateGUID, getByID, getElement, unreachable } from '../utils';
 import { PositioningCallback } from '../utils';
 import { Structure } from '../dataset';
 

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -37,6 +37,7 @@ function createStyleSheet(rules: string[]): CSSStyleSheet {
  * @param structure the structure to convert
  */
 function setup3DmolStructure(model: $3Dmol.GLModel, structure: Structure): void {
+    console.log('setting up 3D mol structure');
     if (structure.cell !== undefined) {
         const cell = structure.cell;
         // prettier-ignore
@@ -168,7 +169,7 @@ export class MoleculeViewer {
      * @param id HTML element id inside which the viewer will be created
      * @param guid (optional) unique identifier for the widget
      */
-    constructor(id: string, guid?: string) {
+    constructor(element: string | HTMLElement, guid?: string) {
         if (guid === undefined) {
             guid = generateGUID();
         }
@@ -179,7 +180,14 @@ export class MoleculeViewer {
         this.guid = 'chsp-' + guid;
 
         this._root = document.createElement('div');
-        const root = getByID(id);
+
+        let root;
+        if (typeof element !== 'string') {
+            root = element;
+        } else {
+            root = getByID(element);
+        }
+
         root.appendChild(this._root);
 
         this._root.style.position = 'relative';
@@ -357,7 +365,6 @@ export class MoleculeViewer {
                 cstyle: { hidden: true },
             });
         }
-
         assignBonds(this._current.model.selectedAtoms({}) as $3Dmol.AtomSpec[]);
         this._current.model.addAtomSpecs(['index']);
 
@@ -412,6 +419,7 @@ export class MoleculeViewer {
      */
     public applySettings(settings: SavedSettings): void {
         this._options.applySettings(settings);
+        console.log('after apply settings');
     }
 
     /**

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -9,7 +9,7 @@ import { default as $3Dmol } from './3dmol';
 import { assignBonds } from './3dmol/assignBonds';
 
 import { SavedSettings } from '../options';
-import { generateGUID, getByID, unreachable } from '../utils';
+import { generateGUID, getByID, unreachable, getElement } from '../utils';
 import { PositioningCallback } from '../utils';
 import { Structure } from '../dataset';
 
@@ -181,14 +181,7 @@ export class MoleculeViewer {
 
         this._root = document.createElement('div');
 
-        let root;
-        if (typeof element !== 'string') {
-            assert(element instanceof HTMLElement);
-            root = element;
-        } else {
-            root = getByID(element);
-        }
-
+        const root = getElement(element);
         root.appendChild(this._root);
 
         this._root.style.position = 'relative';

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -165,7 +165,8 @@ export class MoleculeViewer {
     /**
      * Create a new `MoleculeViewer` inside the HTML DOM element with the given `id`.
      *
-     * @param id HTML element id inside which the viewer will be created
+     * @param element HTML element or HTML id of the DOM element
+     *                where the viewer will be created
      * @param guid (optional) unique identifier for the widget
      */
     constructor(element: string | HTMLElement, guid?: string) {

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -165,8 +165,7 @@ export class MoleculeViewer {
     /**
      * Create a new `MoleculeViewer` inside the HTML DOM element with the given `id`.
      *
-     * @param element HTML element or HTML id of the DOM element
-     *                where the viewer will be created
+     * @param id HTML element id inside which the viewer will be created
      * @param guid (optional) unique identifier for the widget
      */
     constructor(element: string | HTMLElement, guid?: string) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -130,10 +130,10 @@ export function unreachable(): never {
 }
 
 /** Returns the element based on ID or the element itself*/
-export function getElement(element: string | HTMLElement) {
+export function getElement<HTMLElement>(element: string | HTMLElement) {
     if (typeof element !== 'string') {
         assert(element instanceof HTMLElement);
-        return element as HTMLElement;
+        return element;
     } else {
         return getByID<HTMLElement>(element);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,9 +52,15 @@ export function generateGUID(): GUID {
 }
 
 /** Get an HTML element by id */
-export function getByID<HTMLType = HTMLElement>(id: string): HTMLType {
-    const e = document.getElementById(id);
+export function getByID<HTMLType = HTMLElement>(id: string, root?: HTMLElement): HTMLType {
+    let e;
+    if (root !== undefined) {
+        e = root.querySelector(`#${id}`);
+    } else {
+        e = document.getElementById(id);
+    }
     if (e === null) {
+        console.log(root);
         throw Error(`unable to get element with id ${id}`);
     }
     return e as unknown as HTMLType;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,12 +51,12 @@ export function generateGUID(): GUID {
     }) as GUID;
 }
 
-/** 
+/**
  * Get an HTML element by id, looking inside the `root` (by default the whole `document`).
  *
  * The generic parameter `HTMLType` can be used to cast the element to a given type (e.g. `getById<HTMLInputElement>("foo")`) . The element type is not checked by this function.
  *
- * @throws if there is not element with the given id. 
+ * @throws if there is not element with the given id.
  */
 export function getByID<HTMLType = HTMLElement>(id: string, root?: HTMLElement): HTMLType {
     let e;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,7 +51,13 @@ export function generateGUID(): GUID {
     }) as GUID;
 }
 
-/** Get an HTML element by id */
+/** 
+ * Get an HTML element by id, looking inside the `root` (by default the whole `document`).
+ *
+ * The generic parameter `HTMLType` can be used to cast the element to a given type (e.g. `getById<HTMLInputElement>("foo")`) . The element type is not checked by this function.
+ *
+ * @throws if there is not element with the given id. 
+ */
 export function getByID<HTMLType = HTMLElement>(id: string, root?: HTMLElement): HTMLType {
     let e;
     if (root !== undefined) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -135,6 +135,6 @@ export function getElement(element: string | HTMLElement) {
         assert(element instanceof HTMLElement);
         return element;
     } else {
-        return getByID(element);
+        return getByID<HTMLElement>(element);
     }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -60,7 +60,6 @@ export function getByID<HTMLType = HTMLElement>(id: string, root?: HTMLElement):
         e = document.getElementById(id);
     }
     if (e === null) {
-        console.log(root);
         throw Error(`unable to get element with id ${id}`);
     }
     return e as unknown as HTMLType;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -133,7 +133,7 @@ export function unreachable(): never {
 export function getElement(element: string | HTMLElement) {
     if (typeof element !== 'string') {
         assert(element instanceof HTMLElement);
-        return element;
+        return element as HTMLElement;
     } else {
         return getByID<HTMLElement>(element);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -130,7 +130,7 @@ export function unreachable(): never {
 }
 
 /** Returns the element based on ID or the element itself*/
-export function getElement<HTMLElement>(element: string | HTMLElement) {
+export function getElement<HTMLElement>(element: string | HTMLElement): void {
     if (typeof element !== 'string') {
         assert(element instanceof HTMLElement);
         return element;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -128,3 +128,13 @@ export function arrayMaxMin(values: number[]): { max: number; min: number } {
 export function unreachable(): never {
     throw Error('unreachable code entered, this is a bug');
 }
+
+/** Returns the element based on ID or the element itself*/
+export function getElement(element: string | HTMLElement) {
+    if (typeof element !== 'string') {
+        assert(element instanceof HTMLElement);
+        return element;
+    } else {
+        return getByID(element);
+    }
+}


### PR DESCRIPTION
This is an initial step required for the Jupyter Notebook / Lab integration of Chemiscope. No functionality of regular Chemiscope is changed only that the `Config` of the `DefaultVisualizer` can also take in an HTML element rather that the ID of the HTML element. Remaining code was adapted so that the types in `Config` determine the manipulation with the HTML element/ID of the HTML element.