### PR TITLE
Small improvements to the website build on github actions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,13 +38,6 @@ jobs:
           cp chemiscope_standalone.html gh-pages/
           cp -r docs/build/html/ gh-pages/docs/
           rm -f gh-pages/.gitignore
-          tar czf gh-pages.tar.gz gh-pages/
-      - name: store website archive
-        uses: actions/upload-artifact@v1
-        with:
-          name: website
-          path: gh-pages.tar.gz
-
       - name: deploy website to gh-pages
         # only deploy website from master
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -37,7 +37,7 @@ jobs:
           cp dist/*.min.js gh-pages/
           cp chemiscope_standalone.html gh-pages/
           cp -r docs/build/html/ gh-pages/docs/
-          rm -f gh-pages/.gitignore
+          rm -f gh-pages/examples/.gitignore
       - name: deploy website to gh-pages
         # only deploy website from master
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
See the two commits description for the changes.

Nothing major, although without 4373f69 the examples files are not pushed to github and are missing from the website. I manually fixed it on the current gh-pages, but let's fix it for real here!