### PR TITLE
Added setScaleStep for color in Map Options

### DIFF
--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -577,6 +577,7 @@ export class PropertiesMap {
 
             this._options.color.min.value = min;
             this._options.color.max.value = max;
+            this.setScaleStep([min, max], 'color');
         }
 
         this._options.color.property.onchange = () => {
@@ -589,6 +590,7 @@ export class PropertiesMap {
 
                 this._options.color.min.value = min;
                 this._options.color.max.value = max;
+                this.setScaleStep([min, max], 'color');
 
                 this._relayout({
                     'coloraxis.colorbar.title.text': this._title(
@@ -1274,12 +1276,12 @@ export class PropertiesMap {
     }
 
     /** Changes the step of the arrow buttons in min/max input based on dataset range*/
-    private setScaleStep(axisBounds: number[], axisName: string): void {
+    private setScaleStep(axisBounds: number[], name: 'x' | 'y' | 'z' | 'color'): void {
         if (axisBounds !== undefined) {
             // round to 10 decimal places so it does not break in Firefox
             const step = Math.round(((axisBounds[1] - axisBounds[0]) / 20) * 10 ** 10) / 10 ** 10;
-            const minElement = getByID<HTMLInputElement>(`chsp-${axisName}-min`);
-            const maxElement = getByID<HTMLInputElement>(`chsp-${axisName}-max`);
+            const minElement = getByID<HTMLInputElement>(`chsp-${name}-min`);
+            const maxElement = getByID<HTMLInputElement>(`chsp-${name}-max`);
             minElement.step = `${step}`;
             maxElement.step = `${step}`;
         }


### PR DESCRIPTION
Taking setScaleStep from #156 used in x/y/z axis to be also used for color step range.