### PR TITLE
Further Jupyter integration

### DIFF
--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -339,6 +339,11 @@ export class MapOptions extends OptionsGroup {
             }
         });
 
+        // Stop progation of keyboard press (Jupyter widget)
+        modal.addEventListener('keydown', (event) => {
+            event.stopPropagation();
+        });
+
         return { openSettings, modal };
     }
 

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -339,7 +339,8 @@ export class MapOptions extends OptionsGroup {
             }
         });
 
-        // Stop progation when pressing a key (Jupyter widget)
+        // Stop propagation of keydown events. This is required for the Jupyter integration, 
+        // otherwise jupyter tries to interpret key press in the modal as its own input
         modal.addEventListener('keydown', (event) => {
             event.stopPropagation();
         });

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -339,7 +339,7 @@ export class MapOptions extends OptionsGroup {
             }
         });
 
-        // Stop propagation of keydown events. This is required for the Jupyter integration, 
+        // Stop propagation of keydown events. This is required for the Jupyter integration,
         // otherwise jupyter tries to interpret key press in the modal as its own input
         modal.addEventListener('keydown', (event) => {
             event.stopPropagation();

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -339,7 +339,7 @@ export class MapOptions extends OptionsGroup {
             }
         });
 
-        // Stop progation of keyboard press (Jupyter widget)
+        // Stop progation when pressing a key (Jupyter widget)
         modal.addEventListener('keydown', (event) => {
             event.stopPropagation();
         });

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -106,13 +106,14 @@ export class MetadataPanel {
 
         const template = document.createElement('template');
         template.innerHTML = generateModal(this._guid, metadata);
-
-        // Stop progation when pressing a key (Jupyter widget)
-        (template.content.firstChild as HTMLElement).addEventListener('keydown', (event) => {
+        this._modal = template.content.firstChild as HTMLElement;
+        
+        // Stop propagation of keydown events. This is required for the Jupyter integration, 
+        // otherwise jupyter tries to interpret key press in the modal as its own input
+        this._modal.addEventListener('keydown', (event) => {
             event.stopPropagation();
         });
-
-        this._modal = template.content.firstChild as HTMLElement;
+        
         document.body.appendChild(this._modal);
     }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -107,7 +107,7 @@ export class MetadataPanel {
         const template = document.createElement('template');
         template.innerHTML = generateModal(this._guid, metadata);
 
-        // Stop progation of keyboard press (Jupyter widget)
+        // Stop progation when pressing a key (Jupyter widget)
         (template.content.firstChild as HTMLElement).addEventListener('keydown', (event) => {
             event.stopPropagation();
         });

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -106,6 +106,12 @@ export class MetadataPanel {
 
         const template = document.createElement('template');
         template.innerHTML = generateModal(this._guid, metadata);
+
+        // Stop progation of keyboard press (Jupyter widget)
+        (template.content.firstChild as HTMLElement).addEventListener('keydown', (event) => {
+            event.stopPropagation();
+        });
+
         this._modal = template.content.firstChild as HTMLElement;
         document.body.appendChild(this._modal);
     }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -107,13 +107,13 @@ export class MetadataPanel {
         const template = document.createElement('template');
         template.innerHTML = generateModal(this._guid, metadata);
         this._modal = template.content.firstChild as HTMLElement;
-        
-        // Stop propagation of keydown events. This is required for the Jupyter integration, 
+
+        // Stop propagation of keydown events. This is required for the Jupyter integration,
         // otherwise jupyter tries to interpret key press in the modal as its own input
         this._modal.addEventListener('keydown', (event) => {
             event.stopPropagation();
         });
-        
+
         document.body.appendChild(this._modal);
     }
 

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -680,7 +680,10 @@ export class ViewersGrid {
 
             // add a new widget if necessary
             if (!this._viewers.has(cellGUID)) {
-                const widget = new MoleculeViewer(getByID<HTMLElement>(`gi-${cellGUID}`), cellGUID);
+                const widget = new MoleculeViewer(
+                    getByID<HTMLElement>(`gi-${cellGUID}`, this._root),
+                    cellGUID
+                );
 
                 widget.onselect = (atom: number) => {
                     if (this._indexer.mode !== 'atom' || this._active !== cellGUID) {

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -199,7 +199,7 @@ export class StructureOptions extends OptionsGroup {
         // make the settings modal draggable
         makeDraggable(modalDialog, '.modal-header');
 
-        // Stop propagation of keydown events. This is required for the Jupyter integration, 
+        // Stop propagation of keydown events. This is required for the Jupyter integration,
         // otherwise jupyter tries to interpret key press in the modal as its own input
         modal.addEventListener('keydown', (event) => event.stopPropagation());
 

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -199,6 +199,11 @@ export class StructureOptions extends OptionsGroup {
         // make the settings modal draggable
         makeDraggable(modalDialog, '.modal-header');
 
+        // Stop progation of keyboard press (Jupyter widget)
+        modal.addEventListener('keydown', (event) => {
+            event.stopPropagation();
+        });
+
         return modal;
     }
 

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -199,7 +199,8 @@ export class StructureOptions extends OptionsGroup {
         // make the settings modal draggable
         makeDraggable(modalDialog, '.modal-header');
 
-        // Stop progation when pressing a key (Jupyter widget)
+        // Stop propagation of keydown events. This is required for the Jupyter integration, 
+        // otherwise jupyter tries to interpret key press in the modal as its own input
         modal.addEventListener('keydown', (event) => event.stopPropagation());
 
         return modal;

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -199,7 +199,7 @@ export class StructureOptions extends OptionsGroup {
         // make the settings modal draggable
         makeDraggable(modalDialog, '.modal-header');
 
-        // Stop progation of keyboard press (Jupyter widget)
+        // Stop progation when pressing a key (Jupyter widget)
         modal.addEventListener('keydown', (event) => {
             event.stopPropagation();
         });

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -200,9 +200,7 @@ export class StructureOptions extends OptionsGroup {
         makeDraggable(modalDialog, '.modal-header');
 
         // Stop progation when pressing a key (Jupyter widget)
-        modal.addEventListener('keydown', (event) => {
-            event.stopPropagation();
-        });
+        modal.addEventListener('keydown', (event) => event.stopPropagation());
 
         return modal;
     }


### PR DESCRIPTION
Small additions needed for Jupyter widget integration.

Adding a root when creating the Molecule Viewer, and then stopping the propagation on keyboard presses in a modal.