### PR TITLE
Allow to load the same file multiple time

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -200,6 +200,10 @@ export class ChemiscopeApp {
                     settings: dataset.settings || {},
                 };
                 this.load(config, dataset);
+                // clear the selected file name to make sure 'onchange' is
+                // called again if the user loads a file a the same path
+                // multiple time
+                loadDataset.value = '';
                 loadSaveModal.classList.add('fade');
             });
         };
@@ -233,6 +237,10 @@ export class ChemiscopeApp {
                 }
 
                 this.visualizer.applySettings(readJSON(file.name, result));
+                // clear the selected file name to make sure 'onchange' is
+                // called again if the user loads a file a the same path
+                // multiple time
+                loadSettings.value = '';
                 stopLoading();
                 loadSaveModal.classList.add('fade');
             });


### PR DESCRIPTION
If we don't clear the input value, safari and chrome don't call the "onchange" callback again.